### PR TITLE
Introduce a Simple API DSL

### DIFF
--- a/lib/vero.rb
+++ b/lib/vero.rb
@@ -6,6 +6,7 @@ module Vero
   autoload :App,                'vero/app'
   autoload :Context,            'vero/context'
   autoload :Trackable,          'vero/trackable'
+  autoload :DSL,                'vero/dsl'
   
   module Api
     module Workers

--- a/lib/vero/dsl.rb
+++ b/lib/vero/dsl.rb
@@ -1,0 +1,34 @@
+module Vero
+  ##
+  # A lightweight DSL for using the Vero API. You may find this desirable in
+  # your Rails controllers having decided not to mix the Vero gem directly into
+  # your models.
+  #
+  # Example usage:
+  #
+  #   class UsersController < ApplicationController
+  #     include Vero::DSL
+  #
+  #     def update
+  #       vero.users.track!({ ... })
+  #     end
+  #   end
+  module DSL
+    def vero
+      @proxy ||= Proxy.new
+    end
+
+    # :nodoc:
+    class Proxy
+      include Vero::Api
+
+      def users
+        Users
+      end
+
+      def events
+        Events
+      end
+    end
+  end
+end

--- a/spec/lib/dsl_spec.rb
+++ b/spec/lib/dsl_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Vero::DSL do
+  subject(:dsl) { Class.new.extend(Vero::DSL) }
+
+  describe '#vero' do
+    it 'is a proxy to the API' do
+      expect(dsl.vero).to be_an_instance_of(Vero::DSL::Proxy)
+    end
+  end
+end
+
+describe Vero::DSL::Proxy do
+  subject(:proxy) { described_class.new }
+
+  describe '#users' do
+    it 'is a pointer to Vero::Api::Users' do
+      expect(proxy.users).to eql(Vero::Api::Users)
+    end
+  end
+
+  describe '#events' do
+    it 'is a pointer to Vero::Api::Events' do
+      expect(proxy.events).to eql(Vero::Api::Events)
+    end
+  end
+end


### PR DESCRIPTION
This is desirable when you don't want to mix Vero directly into your
models, and do not desire the verbosity of accessing the API modules
directly. Example usage:

``` ruby
class UsersController < ApplicationController
  include Vero::DSL

  def update
    vero.users.track!({ ... })
  end
end
```
