### PR TITLE
Improve validation messages

### DIFF
--- a/lib/vero/api/events/track_api.rb
+++ b/lib/vero/api/events/track_api.rb
@@ -6,20 +6,14 @@ module Vero
           def url
             "#{@domain}/api/v2/events/track.json"
           end
-          
+
           def request
             RestClient.post(self.url, self.request_params_as_json, self.request_content_type)
           end
 
           def validate!
-            result = true
-            result &&= options[:event_name].to_s.blank? == false
-            result &&= (options[:data].nil? || options[:data].is_a?(Hash))
-
-            unless result
-              hash = {:data => options[:data], :event_name => options[:event_name]}
-              raise ArgumentError.new(JSON.dump(hash))
-            end
+            raise ArgumentError.new("Missing :event_name") if options[:event_name].to_s.blank?
+            raise ArgumentError.new(":data must be either nil or a Hash") unless (options[:data].nil? || options[:data].is_a?(Hash))
           end
         end
       end

--- a/lib/vero/api/users/edit_api.rb
+++ b/lib/vero/api/users/edit_api.rb
@@ -12,13 +12,8 @@ module Vero
           end
 
           def validate!
-            result = true
-            result &&= options[:email].to_s.blank? == false
-            result &&= options[:changes].is_a?(Hash)
-
-            unless result
-              raise ArgumentError.new(:email => options[:email], :changes => options[:changes])
-            end
+            raise ArgumentError.new("Missing :email") if options[:email].to_s.blank?
+            raise ArgumentError.new(":changes must be a Hash") unless options[:changes].is_a?(Hash)
           end
         end
       end

--- a/lib/vero/api/users/edit_tags_api.rb
+++ b/lib/vero/api/users/edit_tags_api.rb
@@ -12,13 +12,10 @@ module Vero
           end
 
           def validate!
-            result = true
-            result &&= options[:email].to_s.blank? == false
-            result &&= (options[:add].is_a?(Array) || options[:remove].is_a?(Array))
-
-            unless result
-              raise ArgumentError.new(:email => options[:email], :add => options[:add], :remove => options[:remove])
-            end
+            raise ArgumentError.new("Missing :email") if options[:email].to_s.blank?
+            raise ArgumentError.new(":add must an Array if present") unless options[:add].nil? || options[:add].is_a?(Array)
+            raise ArgumentError.new(":remove must an Array if present") unless options[:remove].nil? || options[:remove].is_a?(Array)
+            raise ArgumentError.new("Either :add or :remove must be present") if (options[:remove].nil? && options[:add].nil?)
           end
         end
       end

--- a/lib/vero/api/users/track_api.rb
+++ b/lib/vero/api/users/track_api.rb
@@ -12,13 +12,8 @@ module Vero
           end
 
           def validate!
-            result = true
-            result &&= options[:email].to_s.blank? == false
-            result &&= (options[:data].nil? || options[:data].is_a?(Hash))
-
-            unless result
-              raise ArgumentError.new(:email => options[:email], :data => options[:data])
-            end
+            raise ArgumentError.new("Missing :email") if options[:email].to_s.blank?
+            raise ArgumentError.new(":data must be either nil or a Hash") unless (options[:data].nil? || options[:data].is_a?(Hash))
           end
         end
       end

--- a/lib/vero/api/users/unsubscribe_api.rb
+++ b/lib/vero/api/users/unsubscribe_api.rb
@@ -12,12 +12,7 @@ module Vero
           end
 
           def validate!
-            result = true
-            result &&= options[:email].to_s.blank? == false
-
-            unless result
-              raise ArgumentError.new(:email => options[:email])
-            end
+            raise ArgumentError.new("Missing :email") if options[:email].to_s.blank?
           end
         end
       end

--- a/spec/lib/api/users/edit_tags_api_spec.rb
+++ b/spec/lib/api/users/edit_tags_api_spec.rb
@@ -11,7 +11,45 @@ describe Vero::Api::Workers::Users::EditTagsAPI do
   end
 
   subject { Vero::Api::Workers::Users::EditTagsAPI.new('https://www.getvero.com', {:auth_token => 'abcd', :email => 'test@test.com', :add => ["test"]}) }
+
   describe :validate! do
+    it "should raise an error if email is a blank String" do
+      options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => nil, :add => []}
+      subject.options = options
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
+
+      options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com', :add => []}
+      subject.options = options
+      expect { subject.send(:validate!) }.to_not raise_error(ArgumentError)
+    end
+
+    it "should raise an error if add is not an Array or missing" do
+      options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com', :add => "foo" }
+
+      subject.options = options
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
+    end
+
+    it "should raise an error if remove is not an Array or missing" do
+      options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com', :remove => "foo" }
+
+      subject.options = options
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
+    end
+
+    it "should raise an error if botha add and remove are missing" do
+      options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com'}
+
+      subject.options = options
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
+    end
+
+    it "should not raise an error if the correct arguments are passed" do
+      options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com', :remove => [ "Hi" ] }
+
+      subject.options = options
+      expect { subject.send(:validate!) }.to_not raise_error(ArgumentError)
+    end
   end
 
   describe :request do

--- a/spec/lib/trackable_spec.rb
+++ b/spec/lib/trackable_spec.rb
@@ -56,9 +56,9 @@ describe Vero::Trackable do
       end
 
       it "should not send a track request when the required parameters are invalid" do
-        expect { @user.track!(nil) }.to raise_error(ArgumentError, "{\"data\":{},\"event_name\":null}")
-        expect { @user.track!('') }.to raise_error(ArgumentError, "{\"data\":{},\"event_name\":\"\"}")
-        expect { @user.track!('test', '') }.to raise_error(ArgumentError, "{\"data\":\"\",\"event_name\":\"test\"}")
+        expect { @user.track!(nil) }.to raise_error(ArgumentError)
+        expect { @user.track!('') }.to raise_error(ArgumentError)
+        expect { @user.track!('test', '') }.to raise_error(ArgumentError)
       end
 
       it "should send a `track!` request when async is set to false" do


### PR DESCRIPTION
Validations were just throwing a stringified hash which did not help
the use of the gem.

Replaced validations with explicit checks and corresponding messages.
Added some missing specs.
