### PR TITLE
Do Not Raise Error With Ruby 2.0

### DIFF
--- a/lib/vero/sender.rb
+++ b/lib/vero/sender.rb
@@ -14,24 +14,23 @@ module Vero
 
   class Sender
     def self.senders
-      @senders ||= begin
-        t = Vero::SenderHash.new
+      t = Vero::SenderHash.new
 
-        t.merge!({
-          true          => Vero::Senders::Invalid,
-          false         => Vero::Senders::Base,
-          :none         => Vero::Senders::Base,
-          :thread       => Vero::Senders::Invalid
-        })
+      t.merge!({
+        true          => Vero::Senders::Invalid,
+        false         => Vero::Senders::Base,
+        :none         => Vero::Senders::Base,
+        :thread       => Vero::Senders::Invalid
+      })
 
-        if RUBY_VERSION =~ /1\.9\./
-          t.merge!(
-            true        => Vero::Senders::Thread,
-            :thread     => Vero::Senders::Thread
-          )
-        end
-        t
+      if RUBY_VERSION !~ /1\.8\./
+        t.merge!(
+          true        => Vero::Senders::Thread,
+          :thread     => Vero::Senders::Thread
+        )
       end
+
+      t
     end
 
     def self.send(api_class, sender_strategy, domain, options)

--- a/spec/lib/sender_spec.rb
+++ b/spec/lib/sender_spec.rb
@@ -2,34 +2,39 @@ require 'spec_helper'
 
 describe Vero::Sender do
   subject { Vero::Sender }
-  describe "self.senders" do
+
+  describe ".senders" do
     it "should be a Hash" do
       subject.senders.should be_a(Hash)
     end
-    
-    unless RUBY_VERSION =~ /1\.9\./
-      context "< Ruby 1.9" do
-        it "should have a default set of senders (true, false, none, thread)" do
-          subject.senders.should == {
-            true          => Vero::Senders::Invalid,
-            false         => Vero::Senders::Base,
-            :none         => Vero::Senders::Base,
-            :thread       => Vero::Senders::Invalid,
-          }
-        end
+
+    context 'when using Ruby 1.8' do
+      before do
+        stub_const('RUBY_VERSION', '1.8.7')
+      end
+
+      it "should have a default set of senders (true, false, none, thread)" do
+        subject.senders.should == {
+          true          => Vero::Senders::Invalid,
+          false         => Vero::Senders::Base,
+          :none         => Vero::Senders::Base,
+          :thread       => Vero::Senders::Invalid,
+        }
       end
     end
 
-    if RUBY_VERSION =~ /1\.9\./
-      context "~> Ruby 1.9" do
-        it "should have a default set of senders (true, false, none, thread)" do
-          subject.senders.should == {
-            true          => Vero::Senders::Thread,
-            false         => Vero::Senders::Base,
-            :none         => Vero::Senders::Base,
-            :thread       => Vero::Senders::Thread,
-          }
-        end
+    context 'when using Ruby with verion greater than 1.8.7' do
+      before do
+        stub_const('RUBY_VERSION', '1.9.3')
+      end
+
+      it "should have a default set of senders (true, false, none, thread)" do
+        subject.senders.should == {
+          true          => Vero::Senders::Thread,
+          false         => Vero::Senders::Base,
+          :none         => Vero::Senders::Base,
+          :thread       => Vero::Senders::Thread,
+        }
       end
     end
 

--- a/spec/lib/trackable_spec.rb
+++ b/spec/lib/trackable_spec.rb
@@ -77,31 +77,39 @@ describe Vero::Trackable do
         @user.track!(@request_params[:event_name]).should == 200
       end
 
-      it "should send using another thread when async is set to true" do
-        context = Vero::Context.new(Vero::App.default_context)
-        context.config.logging = true
-        context.subject = @user
-        context.config.async = true
+      context 'when set to be async' do
+        let(:my_context) { Vero::Context.new(Vero::App.default_context) }
 
-        @user.stub(:with_vero_context).and_return(context)
+        before do
+          my_context.config.logging = true
+          my_context.subject = @user
+          my_context.config.async = true
 
-        if RUBY_VERSION =~ /1\.9\./
-          @user.track!(@request_params[:event_name], @request_params[:data]).should be_true
-          @user.track!(@request_params[:event_name]).should be_true
-        else
-          expect { @user.track!(@request_params[:event_name], @request_params[:data]) }.to raise_error
-          expect { @user.track!(@request_params[:event_name]) }.to raise_error
+          @user.stub(:with_vero_context).and_return(my_context)
+        end
+
+        context 'using Ruby 1.8.7' do
+          before do
+            stub_const('RUBY_VERSION', '1.8.7')
+          end
+
+          it 'raises an error' do
+            expect { @user.track!(@request_params[:event_name], @request_params[:data]) }.to raise_error
+            expect { @user.track!(@request_params[:event_name]) }.to raise_error
+          end
+        end
+
+        context 'not using Ruby 1.8.7' do
+          before do
+            stub_const('RUBY_VERSION', '1.9.3')
+          end
+
+          it 'sends' do
+            @user.track!(@request_params[:event_name], @request_params[:data]).should be_true
+            @user.track!(@request_params[:event_name]).should be_true
+          end
         end
       end
-
-      # it "should raise an error when async is set to false and the request times out" do
-      #   Rails.stub(:logger).and_return(Logger.new('info'))
-      #   context = Vero::App.default_context
-      #   context.config.async = false
-      #   context.config.domain = "200.200.200.200"
-
-      #   expect { @user.track(@request_params[:event_name], @request_params[:data]) }.to raise_error
-      # end
     end
 
     describe :identify! do
@@ -127,17 +135,32 @@ describe Vero::Trackable do
         @user.identify!.should == 200
       end
 
-      it "should send using another thread when async is set to true" do
-        context = Vero::Context.new(Vero::App.default_context)
-        context.subject = @user
-        context.config.async = true
+      context 'when set to use async' do
+        let(:my_context) { Vero::Context.new(Vero::App.default_context) }
 
-        @user.stub(:with_vero_context).and_return(context)
+        before do
+          my_context.subject = @user
+          my_context.config.async = true
+        end
 
-        if RUBY_VERSION =~ /1\.9\./
-          @user.identify!.should be_true
-        else
-          expect { @user.identify! }.to raise_error
+        context 'and using Ruby 1.8.7' do
+          before do
+            stub_const('RUBY_VERSION', '1.8.7')
+          end
+
+          it 'raises an error' do
+            expect { @user.identify! }.to raise_error
+          end
+        end
+
+        context 'and not using Ruby 1.8.7' do
+          before do
+            stub_const('RUBY_VERSION', '1.9.3')
+          end
+
+          it 'sends' do
+            @user.identify!.should be_true
+          end
         end
       end
     end
@@ -177,17 +200,34 @@ describe Vero::Trackable do
         @user.with_vero_context.update_user!.should == 200
       end
 
-      it "should send using another thread when async is set to true" do
-        context = Vero::Context.new(Vero::App.default_context)
-        context.subject = @user
-        context.config.async = true
+      context 'when set to use async' do
+        let(:my_context) { Vero::Context.new(Vero::App.default_context) }
 
-        @user.stub(:with_vero_context).and_return(context)
+        before do
+          my_context.subject = @user
+          my_context.config.async = true
 
-        if RUBY_VERSION =~ /1\.9\./
-          @user.with_vero_context.update_user!.should be_true
-        else
-          expect { @user.with_vero_context.update_user! }.to raise_error
+          @user.stub(:with_vero_context).and_return(my_context)
+        end
+
+        context 'and using Ruby 1.8.7' do
+          before do
+            stub_const('RUBY_VERSION', '1.8.7')
+          end
+
+          it 'raises an error' do
+            expect { @user.with_vero_context.update_user! }.to raise_error
+          end
+        end
+
+        context 'and not using Ruby 1.8.7' do
+          before do
+            stub_const('RUBY_VERSION', '1.9.3')
+          end
+
+          it 'sends' do
+            @user.with_vero_context.update_user!.should be_true
+          end
         end
       end
     end
@@ -253,15 +293,34 @@ describe Vero::Trackable do
         @user.with_vero_context.unsubscribe!.should == 200
       end
 
-      if RUBY_VERSION =~ /1\.9\./
-        it "should send using another thread when async is set to true" do
-          context = Vero::Context.new(Vero::App.default_context)
-          context.subject = @user
-          context.config.async = true
+      context 'when using async' do
+        let(:my_context) { Vero::Context.new(Vero::App.default_context) }
 
-          @user.stub(:with_vero_context).and_return(context)
+        before do
+          my_context.subject = @user
+          my_context.config.async = true
 
-          @user.with_vero_context.unsubscribe!.should be_true
+          @user.stub(:with_vero_context).and_return(my_context)
+        end
+
+        context 'and using Ruby 1.8.7' do
+          before do
+            stub_const('RUBY_VERSION', '1.8.7')
+          end
+
+          it 'raises an error' do
+            expect { @user.with_vero_context.unsubscribe! }.to raise_error
+          end
+        end
+
+        context 'and using Ruby 1.9.3' do
+          before do
+            stub_const('RUBY_VERSION', '1.9.3')
+          end
+
+          it 'sends' do
+            @user.with_vero_context.unsubscribe!.should be_true
+          end
         end
       end
     end


### PR DESCRIPTION
I found that using Ruby 2.0 was causing an error to be raised when
working with the threaded async mode of sending messages. This is no
longer the case as I've removed an artificial constraint preventing use
with Ruby 2.0 from the code, and ensured that testing for 1.8.7
behaviour occurs regardless of the verion of Ruby that is being used to
run the tests.

Note that I've also removed memoization from Sender.senders. It seemed
very unnecessary, and is likely not a performance issue.

This change is not perfect though. There's far too much knowledge about
threading and its limitations scattered throughout the code. This
knowledge should be restricted to the threaded Sender itself.
