### PR TITLE
rename proxy instance variable

### DIFF
--- a/lib/vero/dsl.rb
+++ b/lib/vero/dsl.rb
@@ -15,7 +15,7 @@ module Vero
   #   end
   module DSL
     def vero
-      @proxy ||= Proxy.new
+      @_vero_proxy ||= Proxy.new
     end
 
     # :nodoc:


### PR DESCRIPTION
old name could have interfered with other variables in the model
