### PR TITLE
Fix repository url shown when ran not configured

### DIFF
--- a/lib/vero/api.rb
+++ b/lib/vero/api.rb
@@ -23,7 +23,7 @@ module Vero
       protected
       def validate_configured!
         unless config.configured?
-          raise "You must configure the 'vero' gem. Visit https://github.com/semblancesystems/vero for more details."
+          raise "You must configure the 'vero' gem. Visit https://github.com/getvero/vero for more details."
         end
       end
     end


### PR DESCRIPTION
Hi guys, 

Just a tiny little commit to fix an outdated url being shown when using Vero without configuring it :)
