### PR TITLE
Better specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: ruby
 rvm:
   - "1.9.3"
   - "2.0.0"
-  - "2.1.0"
+  - "2.1.5"
+  - "2.2.0"
 script: bundle exec rspec spec

--- a/spec/lib/api/base_api_spec.rb
+++ b/spec/lib/api/base_api_spec.rb
@@ -5,13 +5,13 @@ describe Vero::Api::Workers::BaseAPI do
 
   describe :options_with_symbolized_keys do
     it "should create a new options Hash with symbol keys (much like Hash#symbolize_keys in rails)" do
-      subject.options.should == {}
+      expect(subject.options).to eq({})
 
       subject.options = {:abc => 123}
-      subject.options.should == {:abc => 123}
+      expect(subject.options).to eq({:abc => 123})
 
       subject.options = {"abc" => 123}
-      subject.options.should == {:abc => 123}
+      expect(subject.options).to eq({:abc => 123})
     end
   end
 end

--- a/spec/lib/api/events/track_api_spec.rb
+++ b/spec/lib/api/events/track_api_spec.rb
@@ -1,20 +1,13 @@
 require 'spec_helper'
 
 describe Vero::Api::Workers::Events::TrackAPI do
+  subject { Vero::Api::Workers::Events::TrackAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => 'test_event'}) }
 
-  context "request without properties" do
-    subject { Vero::Api::Workers::Events::TrackAPI.new('https://api.getvero.com', {}) }
-    it "should inherit from Vero::Api::Workers::BaseCaller" do
-      expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
-    end
-
-    it "should map to current version of Vero API" do
-      expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/events/track.json")
-    end
+  it_behaves_like "a Vero wrapper" do
+    let(:end_point) { "/api/v2/events/track.json" }
   end
 
   context "request with properties" do
-    subject { Vero::Api::Workers::Events::TrackAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => 'test_event'}) }
     describe :validate! do
       it "should raise an error if event_name is a blank String" do
         options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => nil}

--- a/spec/lib/api/events/track_api_spec.rb
+++ b/spec/lib/api/events/track_api_spec.rb
@@ -5,11 +5,11 @@ describe Vero::Api::Workers::Events::TrackAPI do
   context "request without properties" do
     subject { Vero::Api::Workers::Events::TrackAPI.new('https://api.getvero.com', {}) }
     it "should inherit from Vero::Api::Workers::BaseCaller" do
-      subject.should be_a(Vero::Api::Workers::BaseAPI)
+      expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
     end
 
     it "should map to current version of Vero API" do
-      subject.send(:url).should == "https://api.getvero.com/api/v2/events/track.json"
+      expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/events/track.json")
     end
   end
 
@@ -49,8 +49,8 @@ describe Vero::Api::Workers::Events::TrackAPI do
 
     describe :request do
       it "should send a JSON request to the Vero API" do
-        RestClient.should_receive(:post).with("https://api.getvero.com/api/v2/events/track.json", {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => 'test_event'}.to_json, {:content_type => :json, :accept => :json})
-        RestClient.stub(:post).and_return(200)
+        expect(RestClient).to receive(:post).with("https://api.getvero.com/api/v2/events/track.json", {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => 'test_event'}.to_json, {:content_type => :json, :accept => :json})
+        allow(RestClient).to receive(:post).and_return(200)
         subject.send(:request)
       end
     end
@@ -60,7 +60,7 @@ describe Vero::Api::Workers::Events::TrackAPI do
     it "should not raise any errors" do
       obj = Vero::Api::Workers::Events::TrackAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => 'test_event'})
 
-      RestClient.stub(:post).and_return(200)
+      allow(RestClient).to receive(:post).and_return(200)
       expect { obj.perform }.to_not raise_error
     end
   end

--- a/spec/lib/api/events/track_api_spec.rb
+++ b/spec/lib/api/events/track_api_spec.rb
@@ -19,7 +19,7 @@ describe Vero::Api::Workers::Events::TrackAPI do
       it "should raise an error if event_name is a blank String" do
         options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => nil}
         subject.options = options
-        expect { subject.send(:validate!) }.to raise_error
+        expect { subject.send(:validate!) }.to raise_error(ArgumentError)
 
         options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => 'test_event'}
         subject.options = options
@@ -29,7 +29,7 @@ describe Vero::Api::Workers::Events::TrackAPI do
       it "should raise an error if data is not either nil or a Hash" do
         options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => 'test_event', :data => []}
         subject.options = options
-        expect { subject.send(:validate!) }.to raise_error
+        expect { subject.send(:validate!) }.to raise_error(ArgumentError)
 
         options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :event_name => 'test_event', :data => nil}
         subject.options = options

--- a/spec/lib/api/users/edit_api_spec.rb
+++ b/spec/lib/api/users/edit_api_spec.rb
@@ -1,16 +1,12 @@
 require 'spec_helper'
 
 describe Vero::Api::Workers::Users::EditAPI do
-  subject { Vero::Api::Workers::Users::EditAPI.new('https://api.getvero.com', {}) }
-  it "should inherit from Vero::Api::Workers::BaseCaller" do
-    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
-  end
-
-  it "should map to current version of Vero API" do
-    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/edit.json")
-  end
-
   subject { Vero::Api::Workers::Users::EditAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :email => 'test@test.com', :changes => { :email => 'test@test.com' }}) }
+
+  it_behaves_like "a Vero wrapper" do
+    let(:end_point) { "/api/v2/users/edit.json" }
+  end
+
   describe :validate! do
     it "should not raise an error when the keys are Strings" do
       options = {"auth_token" => 'abcd', "email" => 'test@test.com', "changes" => { "email" => 'test@test.com' }}

--- a/spec/lib/api/users/edit_api_spec.rb
+++ b/spec/lib/api/users/edit_api_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe Vero::Api::Workers::Users::EditAPI do
   subject { Vero::Api::Workers::Users::EditAPI.new('https://api.getvero.com', {}) }
   it "should inherit from Vero::Api::Workers::BaseCaller" do
-    subject.should be_a(Vero::Api::Workers::BaseAPI)
+    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
   end
 
   it "should map to current version of Vero API" do
-    subject.send(:url).should == "https://api.getvero.com/api/v2/users/edit.json"
+    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/edit.json")
   end
 
   subject { Vero::Api::Workers::Users::EditAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :email => 'test@test.com', :changes => { :email => 'test@test.com' }}) }
@@ -21,15 +21,15 @@ describe Vero::Api::Workers::Users::EditAPI do
 
   describe :request do
     it "should send a request to the Vero API" do
-      RestClient.should_receive(:put).with("https://api.getvero.com/api/v2/users/edit.json", {:auth_token => 'abcd', :email => 'test@test.com', :changes => { :email => 'test@test.com' }}.to_json, {:content_type => :json, :accept => :json})
-      RestClient.stub(:put).and_return(200)
+      expect(RestClient).to receive(:put).with("https://api.getvero.com/api/v2/users/edit.json", {:auth_token => 'abcd', :email => 'test@test.com', :changes => { :email => 'test@test.com' }}.to_json, {:content_type => :json, :accept => :json})
+      allow(RestClient).to receive(:put).and_return(200)
       subject.send(:request)
     end
   end
 
   describe "integration test" do
     it "should not raise any errors" do
-      RestClient.stub(:put).and_return(200)
+      allow(RestClient).to receive(:put).and_return(200)
       expect { subject.perform }.to_not raise_error
     end
   end

--- a/spec/lib/api/users/edit_tags_api_spec.rb
+++ b/spec/lib/api/users/edit_tags_api_spec.rb
@@ -16,7 +16,7 @@ describe Vero::Api::Workers::Users::EditTagsAPI do
     it "should raise an error if email is a blank String" do
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => nil, :add => []}
       subject.options = options
-      expect { subject.send(:validate!) }.to raise_error
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
 
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com', :add => []}
       subject.options = options
@@ -27,21 +27,21 @@ describe Vero::Api::Workers::Users::EditTagsAPI do
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com', :add => "foo" }
 
       subject.options = options
-      expect { subject.send(:validate!) }.to raise_error
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
     end
 
     it "should raise an error if remove is not an Array or missing" do
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com', :remove => "foo" }
 
       subject.options = options
-      expect { subject.send(:validate!) }.to raise_error
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
     end
 
     it "should raise an error if botha add and remove are missing" do
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com'}
 
       subject.options = options
-      expect { subject.send(:validate!) }.to raise_error
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
     end
 
     it "should not raise an error if the correct arguments are passed" do

--- a/spec/lib/api/users/edit_tags_api_spec.rb
+++ b/spec/lib/api/users/edit_tags_api_spec.rb
@@ -1,16 +1,11 @@
 require 'spec_helper'
 
 describe Vero::Api::Workers::Users::EditTagsAPI do
-  subject { Vero::Api::Workers::Users::EditTagsAPI.new('https://api.getvero.com', {}) }
-  it "should inherit from Vero::Api::Workers::BaseCaller" do
-    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
-  end
-
-  it "should map to current version of Vero API" do
-    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/tags/edit.json")
-  end
-
   subject { Vero::Api::Workers::Users::EditTagsAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :email => 'test@test.com', :add => ["test"]}) }
+
+  it_behaves_like "a Vero wrapper" do
+    let(:end_point) { "/api/v2/users/tags/edit.json" }
+  end
 
   describe :validate! do
     it "should raise an error if email is a blank String" do

--- a/spec/lib/api/users/edit_tags_api_spec.rb
+++ b/spec/lib/api/users/edit_tags_api_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe Vero::Api::Workers::Users::EditTagsAPI do
   subject { Vero::Api::Workers::Users::EditTagsAPI.new('https://api.getvero.com', {}) }
   it "should inherit from Vero::Api::Workers::BaseCaller" do
-    subject.should be_a(Vero::Api::Workers::BaseAPI)
+    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
   end
 
   it "should map to current version of Vero API" do
-    subject.send(:url).should == "https://api.getvero.com/api/v2/users/tags/edit.json"
+    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/tags/edit.json")
   end
 
   subject { Vero::Api::Workers::Users::EditTagsAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :email => 'test@test.com', :add => ["test"]}) }
@@ -60,15 +60,15 @@ describe Vero::Api::Workers::Users::EditTagsAPI do
 
   describe :request do
     it "should send a request to the Vero API" do
-      RestClient.should_receive(:put).with("https://api.getvero.com/api/v2/users/tags/edit.json", {:auth_token => 'abcd', :email => 'test@test.com', :add => ["test"]}.to_json, {:content_type => :json, :accept => :json})
-      RestClient.stub(:put).and_return(200)
+      expect(RestClient).to receive(:put).with("https://api.getvero.com/api/v2/users/tags/edit.json", {:auth_token => 'abcd', :email => 'test@test.com', :add => ["test"]}.to_json, {:content_type => :json, :accept => :json})
+      allow(RestClient).to receive(:put).and_return(200)
       subject.send(:request)
     end
   end
 
   describe "integration test" do
     it "should not raise any errors" do
-      RestClient.stub(:put).and_return(200)
+      allow(RestClient).to receive(:put).and_return(200)
       expect { subject.perform }.to_not raise_error
     end
   end

--- a/spec/lib/api/users/reidentify_spec.rb
+++ b/spec/lib/api/users/reidentify_spec.rb
@@ -1,16 +1,12 @@
 require 'spec_helper'
 
 describe Vero::Api::Workers::Users::ReidentifyAPI do
-  subject { Vero::Api::Workers::Users::ReidentifyAPI.new('https://api.getvero.com', {}) }
-  it "should inherit from Vero::Api::Workers::BaseCaller" do
-    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
-  end
-
-  it "should map to current version of Vero API" do
-    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/reidentify.json")
-  end
-
   subject { Vero::Api::Workers::Users::ReidentifyAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :id => 'test@test.com', :new_id => 'test2@test.com'}) }
+
+  it_behaves_like "a Vero wrapper" do
+    let(:end_point) { "/api/v2/users/reidentify.json" }
+  end
+
   describe :validate! do
     it "should not raise an error when the keys are Strings" do
       options = {"auth_token" => 'abcd', "id" => 'test@test.com', "new_id" => 'test2@test.com'}

--- a/spec/lib/api/users/reidentify_spec.rb
+++ b/spec/lib/api/users/reidentify_spec.rb
@@ -20,12 +20,12 @@ describe Vero::Api::Workers::Users::ReidentifyAPI do
 
     it "should raise an error if id is missing" do
       subject.options = {:auth_token => 'abcd', :new_id => 'test2@test.com'}
-      expect { subject.send(:validate!) }.to raise_error
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
     end
 
     it "should raise an error if new_id is missing" do
       subject.options = {:auth_token => 'abcd', :id => 'test@test.com'}
-      expect { subject.send(:validate!) }.to raise_error
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/lib/api/users/reidentify_spec.rb
+++ b/spec/lib/api/users/reidentify_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe Vero::Api::Workers::Users::ReidentifyAPI do
   subject { Vero::Api::Workers::Users::ReidentifyAPI.new('https://api.getvero.com', {}) }
   it "should inherit from Vero::Api::Workers::BaseCaller" do
-    subject.should be_a(Vero::Api::Workers::BaseAPI)
+    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
   end
 
   it "should map to current version of Vero API" do
-    subject.send(:url).should == "https://api.getvero.com/api/v2/users/reidentify.json"
+    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/reidentify.json")
   end
 
   subject { Vero::Api::Workers::Users::ReidentifyAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :id => 'test@test.com', :new_id => 'test2@test.com'}) }
@@ -31,15 +31,15 @@ describe Vero::Api::Workers::Users::ReidentifyAPI do
 
   describe :request do
     it "should send a request to the Vero API" do
-      RestClient.should_receive(:put).with("https://api.getvero.com/api/v2/users/reidentify.json", {:auth_token => 'abcd', :id => 'test@test.com', :new_id => 'test2@test.com'}.to_json, {:content_type => :json, :accept => :json})
-      RestClient.stub(:put).and_return(200)
+      expect(RestClient).to receive(:put).with("https://api.getvero.com/api/v2/users/reidentify.json", {:auth_token => 'abcd', :id => 'test@test.com', :new_id => 'test2@test.com'}.to_json, {:content_type => :json, :accept => :json})
+      allow(RestClient).to receive(:put).and_return(200)
       subject.send(:request)
     end
   end
 
   describe "integration test" do
     it "should not raise any errors" do
-      RestClient.stub(:put).and_return(200)
+      allow(RestClient).to receive(:put).and_return(200)
       expect { subject.perform }.to_not raise_error
     end
   end

--- a/spec/lib/api/users/track_api_spec.rb
+++ b/spec/lib/api/users/track_api_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe Vero::Api::Workers::Users::TrackAPI do
   subject { Vero::Api::Workers::Users::TrackAPI.new('https://api.getvero.com', {}) }
   it "should inherit from Vero::Api::Workers::BaseCaller" do
-    subject.should be_a(Vero::Api::Workers::BaseAPI)
+    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
   end
 
   it "should map to current version of Vero API" do
-    subject.send(:url).should == "https://api.getvero.com/api/v2/users/track.json"
+    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/track.json")
   end
 
   subject { Vero::Api::Workers::Users::TrackAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com'}) }
@@ -53,15 +53,15 @@ describe Vero::Api::Workers::Users::TrackAPI do
 
   describe :request do
     it "should send a request to the Vero API" do
-      RestClient.should_receive(:post).with("https://api.getvero.com/api/v2/users/track.json", {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com'}.to_json, {:content_type => :json, :accept => :json})
-      RestClient.stub(:post).and_return(200)
+      expect(RestClient).to receive(:post).with("https://api.getvero.com/api/v2/users/track.json", {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com'}.to_json, {:content_type => :json, :accept => :json})
+      allow(RestClient).to receive(:post).and_return(200)
       subject.send(:request)
     end
   end
 
   describe "integration test" do
     it "should not raise any errors" do
-      RestClient.stub(:post).and_return(200)
+      allow(RestClient).to receive(:post).and_return(200)
       expect { subject.perform }.to_not raise_error
     end
   end

--- a/spec/lib/api/users/track_api_spec.rb
+++ b/spec/lib/api/users/track_api_spec.rb
@@ -1,16 +1,12 @@
 require 'spec_helper'
 
 describe Vero::Api::Workers::Users::TrackAPI do
-  subject { Vero::Api::Workers::Users::TrackAPI.new('https://api.getvero.com', {}) }
-  it "should inherit from Vero::Api::Workers::BaseCaller" do
-    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
-  end
-
-  it "should map to current version of Vero API" do
-    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/track.json")
-  end
-
   subject { Vero::Api::Workers::Users::TrackAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com'}) }
+
+  it_behaves_like "a Vero wrapper" do
+    let(:end_point) { "/api/v2/users/track.json" }
+  end
+
   describe :validate! do
     it "should raise an error if email and id are are blank String" do
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :id => nil, :email => nil}

--- a/spec/lib/api/users/track_api_spec.rb
+++ b/spec/lib/api/users/track_api_spec.rb
@@ -15,7 +15,7 @@ describe Vero::Api::Workers::Users::TrackAPI do
     it "should raise an error if email and id are are blank String" do
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :id => nil, :email => nil}
       subject.options = options
-      expect { subject.send(:validate!) }.to raise_error
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
 
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :id => nil, :email => 'test@test.com'}
       subject.options = options
@@ -23,7 +23,7 @@ describe Vero::Api::Workers::Users::TrackAPI do
 
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :id => "", :email => nil}
       subject.options = options
-      expect { subject.send(:validate!) }.to raise_error
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
 
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :id => "user123", :email => nil}
       subject.options = options
@@ -33,7 +33,7 @@ describe Vero::Api::Workers::Users::TrackAPI do
     it "should raise an error if data is not either nil or a Hash" do
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com', :data => []}
       subject.options = options
-      expect { subject.send(:validate!) }.to raise_error
+      expect { subject.send(:validate!) }.to raise_error(ArgumentError)
 
       options = {:auth_token => 'abcd', :identity => {:email => 'test@test.com'}, :email => 'test@test.com', :data => nil}
       subject.options = options

--- a/spec/lib/api/users/unsubscribe_api_spec.rb
+++ b/spec/lib/api/users/unsubscribe_api_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe Vero::Api::Workers::Users::UnsubscribeAPI do
   subject { Vero::Api::Workers::Users::UnsubscribeAPI.new('https://api.getvero.com', {}) }
   it "should inherit from Vero::Api::Workers::BaseCaller" do
-    subject.should be_a(Vero::Api::Workers::BaseAPI)
+    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
   end
 
   it "should map to current version of Vero API" do
-    subject.send(:url).should == "https://api.getvero.com/api/v2/users/unsubscribe.json"
+    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/unsubscribe.json")
   end
 
   subject { Vero::Api::Workers::Users::UnsubscribeAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :email => 'test@test.com', :changes => { :email => 'test@test.com' }}) }
@@ -21,15 +21,15 @@ describe Vero::Api::Workers::Users::UnsubscribeAPI do
 
   describe :request do
     it "should send a request to the Vero API" do
-      RestClient.should_receive(:post).with("https://api.getvero.com/api/v2/users/unsubscribe.json", {:auth_token => 'abcd', :email => 'test@test.com', :changes => { :email => 'test@test.com' }})
-      RestClient.stub(:post).and_return(200)
+      expect(RestClient).to receive(:post).with("https://api.getvero.com/api/v2/users/unsubscribe.json", {:auth_token => 'abcd', :email => 'test@test.com', :changes => { :email => 'test@test.com' }})
+      allow(RestClient).to receive(:post).and_return(200)
       subject.send(:request)
     end
   end
 
   describe "integration test" do
     it "should not raise any errors" do
-      RestClient.stub(:post).and_return(200)
+      allow(RestClient).to receive(:post).and_return(200)
       expect { subject.perform }.to_not raise_error
     end
   end

--- a/spec/lib/api/users/unsubscribe_api_spec.rb
+++ b/spec/lib/api/users/unsubscribe_api_spec.rb
@@ -1,16 +1,12 @@
 require 'spec_helper'
 
 describe Vero::Api::Workers::Users::UnsubscribeAPI do
-  subject { Vero::Api::Workers::Users::UnsubscribeAPI.new('https://api.getvero.com', {}) }
-  it "should inherit from Vero::Api::Workers::BaseCaller" do
-    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
-  end
-
-  it "should map to current version of Vero API" do
-    expect(subject.send(:url)).to eq("https://api.getvero.com/api/v2/users/unsubscribe.json")
-  end
-
   subject { Vero::Api::Workers::Users::UnsubscribeAPI.new('https://api.getvero.com', {:auth_token => 'abcd', :email => 'test@test.com', :changes => { :email => 'test@test.com' }}) }
+
+  it_behaves_like "a Vero wrapper" do
+    let(:end_point) { "/api/v2/users/unsubscribe.json" }
+  end
+
   describe :validate! do
     it "should not raise an error when the keys are Strings" do
       options = {"auth_token" => 'abcd', "email" => 'test@test.com', "changes" => { "email" => 'test@test.com' }}

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -9,13 +9,13 @@ describe Vero::Api::Events do
       expected = input.merge(:auth_token => "abc123", :development_mode => true)
 
       mock_context = Vero::Context.new
-      mock_context.config.stub(:configured?).and_return(true)
-      mock_context.config.stub(:auth_token).and_return("abc123")
-      mock_context.config.stub(:development_mode).and_return(true)
+      allow(mock_context.config).to receive(:configured?).and_return(true)
+      allow(mock_context.config).to receive(:auth_token).and_return("abc123")
+      allow(mock_context.config).to receive(:development_mode).and_return(true)
 
-      Vero::App.stub(:default_context).and_return(mock_context)
+      allow(Vero::App).to receive(:default_context).and_return(mock_context)
 
-      Vero::Sender.should_receive(:send).with(Vero::Api::Workers::Events::TrackAPI, true, "https://api.getvero.com", expected)
+      expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Events::TrackAPI, true, "https://api.getvero.com", expected)
 
       subject.track!(input)
     end
@@ -31,13 +31,13 @@ describe Vero::Api::Users do
       expected = input.merge(:auth_token => "abc123", :development_mode => true)
 
       mock_context = Vero::Context.new
-      mock_context.config.stub(:configured?).and_return(true)
-      mock_context.config.stub(:auth_token).and_return("abc123")
-      mock_context.config.stub(:development_mode).and_return(true)
+      allow(mock_context.config).to receive(:configured?).and_return(true)
+      allow(mock_context.config).to receive(:auth_token).and_return("abc123")
+      allow(mock_context.config).to receive(:development_mode).and_return(true)
 
-      Vero::App.stub(:default_context).and_return(mock_context)
+      allow(Vero::App).to receive(:default_context).and_return(mock_context)
 
-      Vero::Sender.should_receive(:send).with(Vero::Api::Workers::Users::TrackAPI, true, "https://api.getvero.com", expected)
+      expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::TrackAPI, true, "https://api.getvero.com", expected)
 
       subject.track!(input)
     end
@@ -49,13 +49,13 @@ describe Vero::Api::Users do
       expected = input.merge(:auth_token => "abc123", :development_mode => true)
 
       mock_context = Vero::Context.new
-      mock_context.config.stub(:configured?).and_return(true)
-      mock_context.config.stub(:auth_token).and_return("abc123")
-      mock_context.config.stub(:development_mode).and_return(true)
+      allow(mock_context.config).to receive(:configured?).and_return(true)
+      allow(mock_context.config).to receive(:auth_token).and_return("abc123")
+      allow(mock_context.config).to receive(:development_mode).and_return(true)
 
-      Vero::App.stub(:default_context).and_return(mock_context)
+      allow(Vero::App).to receive(:default_context).and_return(mock_context)
 
-      Vero::Sender.should_receive(:send).with(Vero::Api::Workers::Users::EditAPI, true, "https://api.getvero.com", expected)
+      expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::EditAPI, true, "https://api.getvero.com", expected)
 
       subject.edit_user!(input)
     end
@@ -67,13 +67,13 @@ describe Vero::Api::Users do
       expected = input.merge(:auth_token => "abc123", :development_mode => true)
 
       mock_context = Vero::Context.new
-      mock_context.config.stub(:configured?).and_return(true)
-      mock_context.config.stub(:auth_token).and_return("abc123")
-      mock_context.config.stub(:development_mode).and_return(true)
+      allow(mock_context.config).to receive(:configured?).and_return(true)
+      allow(mock_context.config).to receive(:auth_token).and_return("abc123")
+      allow(mock_context.config).to receive(:development_mode).and_return(true)
 
-      Vero::App.stub(:default_context).and_return(mock_context)
+      allow(Vero::App).to receive(:default_context).and_return(mock_context)
 
-      Vero::Sender.should_receive(:send).with(Vero::Api::Workers::Users::EditTagsAPI, true, "https://api.getvero.com", expected)
+      expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::EditTagsAPI, true, "https://api.getvero.com", expected)
 
       subject.edit_user_tags!(input)
     end
@@ -85,12 +85,12 @@ describe Vero::Api::Users do
       expected = input.merge(:auth_token => "abc123", :development_mode => false)
 
       mock_context = Vero::Context.new
-      mock_context.config.stub(:configured?).and_return(true)
-      mock_context.config.stub(:auth_token).and_return("abc123")
+      allow(mock_context.config).to receive(:configured?).and_return(true)
+      allow(mock_context.config).to receive(:auth_token).and_return("abc123")
 
-      Vero::App.stub(:default_context).and_return(mock_context)
+      allow(Vero::App).to receive(:default_context).and_return(mock_context)
 
-      Vero::Sender.should_receive(:send).with(Vero::Api::Workers::Users::UnsubscribeAPI, true, "https://api.getvero.com", expected)
+      expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::UnsubscribeAPI, true, "https://api.getvero.com", expected)
 
       subject.unsubscribe!(input)
     end

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -23,76 +23,58 @@ describe Vero::Api::Events do
 end
 
 describe Vero::Api::Users do
-  let (:subject) { Vero::Api::Users }
+  let(:subject) { Vero::Api::Users }
+  let(:mock_context) { Vero::Context.new }
+  let(:expected) { input.merge(:auth_token => "abc123", :development_mode => true) }
+
+  before :each do
+    allow(mock_context.config).to receive(:configured?).and_return(true)
+    allow(mock_context.config).to receive(:auth_token).and_return("abc123")
+    allow(mock_context.config).to receive(:development_mode).and_return(true)
+    allow(Vero::App).to receive(:default_context).and_return(mock_context)
+  end
 
   describe :track! do
-    it "should call the TrackAPI object via the configured sender" do
-      input = {:email => "james@getvero.com", :data => {:age => 25}}
-      expected = input.merge(:auth_token => "abc123", :development_mode => true)
+    context "should call the TrackAPI object via the configured sender" do
+      let(:input) { {:email => "james@getvero.com", :data => {:age => 25}} }
 
-      mock_context = Vero::Context.new
-      allow(mock_context.config).to receive(:configured?).and_return(true)
-      allow(mock_context.config).to receive(:auth_token).and_return("abc123")
-      allow(mock_context.config).to receive(:development_mode).and_return(true)
-
-      allow(Vero::App).to receive(:default_context).and_return(mock_context)
-
-      expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::TrackAPI, true, "https://api.getvero.com", expected)
-
-      subject.track!(input)
+      specify do
+        expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::TrackAPI, true, "https://api.getvero.com", expected)
+        subject.track!(input)
+      end
     end
   end
 
   describe :edit_user! do
-    it "should call the TrackAPI object via the configured sender" do
-      input = {:email => "james@getvero.com", :changes => {:age => 25}}
-      expected = input.merge(:auth_token => "abc123", :development_mode => true)
+    context "should call the TrackAPI object via the configured sender" do
+      let(:input) { {:email => "james@getvero.com", :changes => {:age => 25}} }
 
-      mock_context = Vero::Context.new
-      allow(mock_context.config).to receive(:configured?).and_return(true)
-      allow(mock_context.config).to receive(:auth_token).and_return("abc123")
-      allow(mock_context.config).to receive(:development_mode).and_return(true)
-
-      allow(Vero::App).to receive(:default_context).and_return(mock_context)
-
-      expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::EditAPI, true, "https://api.getvero.com", expected)
-
-      subject.edit_user!(input)
+      specify do
+        expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::EditAPI, true, "https://api.getvero.com", expected)
+        subject.edit_user!(input)
+      end
     end
   end
 
   describe :edit_user_tags! do
-    it "should call the TrackAPI object via the configured sender" do
-      input = {:add => ["boom"], :remove => ["tish"]}
-      expected = input.merge(:auth_token => "abc123", :development_mode => true)
+    context "should call the TrackAPI object via the configured sender" do
+      let(:input) { {:add => ["boom"], :remove => ["tish"]} }
 
-      mock_context = Vero::Context.new
-      allow(mock_context.config).to receive(:configured?).and_return(true)
-      allow(mock_context.config).to receive(:auth_token).and_return("abc123")
-      allow(mock_context.config).to receive(:development_mode).and_return(true)
-
-      allow(Vero::App).to receive(:default_context).and_return(mock_context)
-
-      expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::EditTagsAPI, true, "https://api.getvero.com", expected)
-
-      subject.edit_user_tags!(input)
+      specify do
+        expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::EditTagsAPI, true, "https://api.getvero.com", expected)
+        subject.edit_user_tags!(input)
+      end
     end
   end
 
   describe :unsubscribe! do
-    it "should call the TrackAPI object via the configured sender" do
-      input = {:email => "james@getvero"}
-      expected = input.merge(:auth_token => "abc123", :development_mode => false)
+    context "should call the TrackAPI object via the configured sender" do
+      let(:input) { {:email => "james@getvero"} }
 
-      mock_context = Vero::Context.new
-      allow(mock_context.config).to receive(:configured?).and_return(true)
-      allow(mock_context.config).to receive(:auth_token).and_return("abc123")
-
-      allow(Vero::App).to receive(:default_context).and_return(mock_context)
-
-      expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::UnsubscribeAPI, true, "https://api.getvero.com", expected)
-
-      subject.unsubscribe!(input)
+      specify do
+        expect(Vero::Sender).to receive(:send).with(Vero::Api::Workers::Users::UnsubscribeAPI, true, "https://api.getvero.com", expected)
+        subject.unsubscribe!(input)
+      end
     end
   end
 end

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -4,7 +4,7 @@ describe Vero::App do
   describe 'self.default_context' do
     it "inherits from Vero::Context" do
       actual = Vero::App.default_context
-      actual.should be_a(Vero::Context)
+      expect(actual).to be_a(Vero::Context)
     end
   end
 
@@ -12,46 +12,46 @@ describe Vero::App do
   describe :init do
     it "should ignore configuring the config if no block is provided" do
       Vero::App.init
-      context.configured?.should be(false)
+      expect(context.configured?).to be(false)
     end
 
     it "should pass configuration defined in the block to the config file" do
       Vero::App.init
 
-      context.config.api_key.should be_nil
+      expect(context.config.api_key).to be_nil
       Vero::App.init do |c|
         c.api_key = "abcd1234"
       end
-      context.config.api_key.should == "abcd1234"
+      expect(context.config.api_key).to eq("abcd1234")
     end
 
     it "should init should be able to set async" do
       Vero::App.init do |c|
         c.async = false
       end
-      context.config.async.should be(false)
+      expect(context.config.async).to be(false)
 
       Vero::App.init do |c|
         c.async = true
       end
-      context.config.async.should be(true)
+      expect(context.config.async).to be(true)
     end
   end
 
   describe :disable_requests! do
     it "should change config.disabled" do
       Vero::App.init {}
-      context.config.disabled.should be(false)
+      expect(context.config.disabled).to be(false)
 
       Vero::App.disable_requests!
-      context.config.disabled.should be(true)
+      expect(context.config.disabled).to be(true)
     end
   end
 
   describe :log do
     it "should have a log method" do
       Vero::App.init {}
-      Vero::App.should_receive(:log)
+      expect(Vero::App).to receive(:log)
       Vero::App.log(Object, "test")
     end
   end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1,76 +1,74 @@
 require 'spec_helper'
 
 describe Vero::Config do
-  before :each do
-    @config = Vero::Config.new
-  end
+  let(:config) { Vero::Config.new }
 
   it "should be async by default" do
-    expect(@config.async).to be(true)
+    expect(config.async).to be(true)
   end
 
   describe :reset! do
     it "should reset all attributes" do
-      @config.api_key = "abcd1234"
-      @config.secret  = "abcd1234"
+      config.api_key = "abcd1234"
+      config.secret  = "abcd1234"
+      config.reset!
 
-      @config.reset!
-      expect(@config.api_key).to be_nil
-      expect(@config.secret).to be_nil
+      expect(config.api_key).to be_nil
+      expect(config.secret).to be_nil
     end
   end
 
   describe :auth_token do
     it "should return nil if either api_key or secret are not set" do
-      @config.api_key = nil
-      @config.secret = "abcd"
-      expect(@config.auth_token).to be_nil
+      config.api_key = nil
+      config.secret = "abcd"
+      expect(config.auth_token).to be_nil
 
-      @config.api_key = "abcd"
-      @config.secret = nil
-      expect(@config.auth_token).to be_nil
+      config.api_key = "abcd"
+      config.secret = nil
+      expect(config.auth_token).to be_nil
 
-      @config.api_key = "abcd"
-      @config.secret = "abcd"
-      expect(@config.auth_token).not_to be_nil
+      config.api_key = "abcd"
+      config.secret = "abcd"
+      expect(config.auth_token).not_to be_nil
     end
 
     it "should return an expected auth_token" do
-      @config.api_key = "abcd1234"
-      @config.secret = "efgh5678"
-      expect(@config.auth_token).to eq("YWJjZDEyMzQ6ZWZnaDU2Nzg=")
+      config.api_key = "abcd1234"
+      config.secret = "efgh5678"
+      expect(config.auth_token).to eq("YWJjZDEyMzQ6ZWZnaDU2Nzg=")
     end
   end
 
   describe :request_params do
     it "should return a hash of auth_token and development_mode if they are set" do
-      @config.api_key = nil
-      @config.secret = nil
-      @config.development_mode = nil
-      expect(@config.request_params).to eq({})
+      config.api_key = nil
+      config.secret = nil
+      config.development_mode = nil
+      expect(config.request_params).to eq({})
 
-      @config.api_key = "abcd1234"
-      @config.secret = "abcd1234"
-      expect(@config.request_params).to eq({:auth_token => "YWJjZDEyMzQ6YWJjZDEyMzQ="})
+      config.api_key = "abcd1234"
+      config.secret = "abcd1234"
+      expect(config.request_params).to eq({:auth_token => "YWJjZDEyMzQ6YWJjZDEyMzQ="})
 
-      @config.development_mode = true
-      expect(@config.request_params).to eq({:auth_token => "YWJjZDEyMzQ6YWJjZDEyMzQ=", :development_mode => true})
+      config.development_mode = true
+      expect(config.request_params).to eq({:auth_token => "YWJjZDEyMzQ6YWJjZDEyMzQ=", :development_mode => true})
     end
   end
 
   describe :domain do
     it "should return https://api.getvero.com when not set" do
-      expect(@config.domain).to eq('https://api.getvero.com')
-      @config.domain = 'blah.com'
-      expect(@config.domain).not_to eq('https://api.getvero.com')
+      expect(config.domain).to eq('https://api.getvero.com')
+      config.domain = 'blah.com'
+      expect(config.domain).not_to eq('https://api.getvero.com')
     end
 
     it "should return the domain value" do
-      @config.domain = 'test.unbelieveable.com.au'
-      expect(@config.domain).to eq('http://test.unbelieveable.com.au')
+      config.domain = 'test.unbelieveable.com.au'
+      expect(config.domain).to eq('http://test.unbelieveable.com.au')
 
-      @config.domain = 'http://test.unbelieveable.com.au'
-      expect(@config.domain).to eq('http://test.unbelieveable.com.au')
+      config.domain = 'http://test.unbelieveable.com.au'
+      expect(config.domain).to eq('http://test.unbelieveable.com.au')
     end
   end
 
@@ -93,11 +91,11 @@ describe Vero::Config do
     end
 
     it "can be overritten with the config block" do
-      @config.development_mode = true
-      expect(@config.request_params[:development_mode]).to be(true)
+      config.development_mode = true
+      expect(config.request_params[:development_mode]).to be(true)
 
-      @config.reset!
-      expect(@config.request_params[:development_mode]).to be(false)
+      config.reset!
+      expect(config.request_params[:development_mode]).to be(false)
     end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -6,7 +6,7 @@ describe Vero::Config do
   end
 
   it "should be async by default" do
-    @config.async.should be(true)
+    expect(@config.async).to be(true)
   end
 
   describe :reset! do
@@ -15,8 +15,8 @@ describe Vero::Config do
       @config.secret  = "abcd1234"
 
       @config.reset!
-      @config.api_key.should be_nil
-      @config.secret.should be_nil
+      expect(@config.api_key).to be_nil
+      expect(@config.secret).to be_nil
     end
   end
 
@@ -24,21 +24,21 @@ describe Vero::Config do
     it "should return nil if either api_key or secret are not set" do
       @config.api_key = nil
       @config.secret = "abcd"
-      @config.auth_token.should be_nil
+      expect(@config.auth_token).to be_nil
 
       @config.api_key = "abcd"
       @config.secret = nil
-      @config.auth_token.should be_nil
+      expect(@config.auth_token).to be_nil
 
       @config.api_key = "abcd"
       @config.secret = "abcd"
-      @config.auth_token.should_not be_nil
+      expect(@config.auth_token).not_to be_nil
     end
 
     it "should return an expected auth_token" do
       @config.api_key = "abcd1234"
       @config.secret = "efgh5678"
-      @config.auth_token.should == "YWJjZDEyMzQ6ZWZnaDU2Nzg="
+      expect(@config.auth_token).to eq("YWJjZDEyMzQ6ZWZnaDU2Nzg=")
     end
   end
 
@@ -47,30 +47,30 @@ describe Vero::Config do
       @config.api_key = nil
       @config.secret = nil
       @config.development_mode = nil
-      @config.request_params.should == {}
+      expect(@config.request_params).to eq({})
 
       @config.api_key = "abcd1234"
       @config.secret = "abcd1234"
-      @config.request_params.should == {:auth_token => "YWJjZDEyMzQ6YWJjZDEyMzQ="}
+      expect(@config.request_params).to eq({:auth_token => "YWJjZDEyMzQ6YWJjZDEyMzQ="})
 
       @config.development_mode = true
-      @config.request_params.should == {:auth_token => "YWJjZDEyMzQ6YWJjZDEyMzQ=", :development_mode => true}
+      expect(@config.request_params).to eq({:auth_token => "YWJjZDEyMzQ6YWJjZDEyMzQ=", :development_mode => true})
     end
   end
 
   describe :domain do
     it "should return https://api.getvero.com when not set" do
-      @config.domain.should == 'https://api.getvero.com'
+      expect(@config.domain).to eq('https://api.getvero.com')
       @config.domain = 'blah.com'
-      @config.domain.should_not == 'https://api.getvero.com'
+      expect(@config.domain).not_to eq('https://api.getvero.com')
     end
 
     it "should return the domain value" do
       @config.domain = 'test.unbelieveable.com.au'
-      @config.domain.should == 'http://test.unbelieveable.com.au'
+      expect(@config.domain).to eq('http://test.unbelieveable.com.au')
 
       @config.domain = 'http://test.unbelieveable.com.au'
-      @config.domain.should == 'http://test.unbelieveable.com.au'
+      expect(@config.domain).to eq('http://test.unbelieveable.com.au')
     end
   end
 
@@ -78,26 +78,26 @@ describe Vero::Config do
     it "by default it should return false regardless of Rails environment" do
       stub_env('development') {
         config = Vero::Config.new
-        config.development_mode.should be(false)
+        expect(config.development_mode).to be(false)
       }
 
       stub_env('test') {
         config = Vero::Config.new
-        config.development_mode.should be(false)
+        expect(config.development_mode).to be(false)
       }
 
       stub_env('production') {
         config = Vero::Config.new
-        config.development_mode.should be(false)
+        expect(config.development_mode).to be(false)
       }
     end
 
     it "can be overritten with the config block" do
       @config.development_mode = true
-      @config.request_params[:development_mode].should be(true)
+      expect(@config.request_params[:development_mode]).to be(true)
 
       @config.reset!
-      @config.request_params[:development_mode].should be(false)
+      expect(@config.request_params[:development_mode]).to be(false)
     end
   end
 end

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -5,53 +5,53 @@ describe Vero::Context do
 
   it "accepts multiple parameter types in contructor" do
     context1 = Vero::Context.new({ :api_key => 'blah', :secret => 'didah' })
-    context1.should be_a(Vero::Context)
-    context1.config.api_key.should == 'blah'
-    context1.config.secret.should == 'didah'
+    expect(context1).to be_a(Vero::Context)
+    expect(context1.config.api_key).to eq('blah')
+    expect(context1.config.secret).to eq('didah')
 
     context2 = Vero::Context.new(context1)
-    context2.should be_a(Vero::Context)
-    context2.should_not be(context1)
-    context2.config.api_key.should == 'blah'
-    context2.config.secret.should == 'didah'
+    expect(context2).to be_a(Vero::Context)
+    expect(context2).not_to be(context1)
+    expect(context2.config.api_key).to eq('blah')
+    expect(context2.config.secret).to eq('didah')
 
     context3 = Vero::Context.new VeroUser.new('api_key', 'secret')
-    context3.should be_a(Vero::Context)
-    context3.config.api_key.should == 'api_key'
-    context3.config.secret.should == 'secret'
+    expect(context3).to be_a(Vero::Context)
+    expect(context3.config.api_key).to eq('api_key')
+    expect(context3.config.secret).to eq('secret')
   end
 
   describe :configure do
     it "should ignore configuring the config if no block is provided" do
       context.configure
-      context.configured?.should be(false)
+      expect(context.configured?).to be(false)
     end
 
     it "should pass configuration defined in the block to the config file" do
       context.configure do |c|
         c.api_key = "abcd1234"
       end
-      context.config.api_key.should == "abcd1234"
+      expect(context.config.api_key).to eq("abcd1234")
     end
 
     it "should init should be able to set async" do
       context.configure do |c|
         c.async = false
       end
-      context.config.async.should be(false)
+      expect(context.config.async).to be(false)
 
       context.configure do |c|
         c.async = true
       end
-      context.config.async.should be(true)
+      expect(context.config.async).to be(true)
     end
   end
 
   describe :disable_requests! do
     it "should change config.disabled" do
-      context.config.disabled.should be(false)
+      expect(context.config.disabled).to be(false)
       context.disable_requests!
-      context.config.disabled.should be(true)            
+      expect(context.config.disabled).to be(true)            
     end
   end
 end

--- a/spec/lib/sender_spec.rb
+++ b/spec/lib/sender_spec.rb
@@ -5,7 +5,7 @@ describe Vero::Sender do
 
   describe ".senders" do
     it "should be a Hash" do
-      subject.senders.should be_a(Hash)
+      expect(subject.senders).to be_a(Hash)
     end
 
     context 'when using Ruby with verion greater than 1.8.7' do
@@ -14,20 +14,20 @@ describe Vero::Sender do
       end
 
       it "should have a default set of senders (true, false, none, thread)" do
-        subject.senders.should == {
+        expect(subject.senders).to eq({
           true          => Vero::Senders::Thread,
           false         => Vero::Senders::Base,
           :none         => Vero::Senders::Base,
           :thread       => Vero::Senders::Thread,
-        }
+        })
       end
     end
 
     it "should automatically find senders that are not defined" do
-      subject.senders[:delayed_job].should  == Vero::Senders::DelayedJob
-      subject.senders[:resque].should       == Vero::Senders::Resque
-      subject.senders[:invalid].should      == Vero::Senders::Invalid
-      subject.senders[:none].should         == Vero::Senders::Base
+      expect(subject.senders[:delayed_job]).to  eq(Vero::Senders::DelayedJob)
+      expect(subject.senders[:resque]).to       eq(Vero::Senders::Resque)
+      expect(subject.senders[:invalid]).to      eq(Vero::Senders::Invalid)
+      expect(subject.senders[:none]).to         eq(Vero::Senders::Base)
     end
   end
 end

--- a/spec/lib/trackable_spec.rb
+++ b/spec/lib/trackable_spec.rb
@@ -30,7 +30,7 @@ describe Vero::Trackable do
     it "should raise an error when API requests are made" do
       expect { @user.track(@request_params[:event_name], @request_params[:data]) }.to raise_error
 
-      @user.stub(:post_later).and_return('success')
+      allow(@user).to receive(:post_later).and_return('success')
       expect { @user.identity! }.to raise_error
     end
   end
@@ -63,31 +63,31 @@ describe Vero::Trackable do
 
       it "should send a `track!` request when async is set to false" do
         context = vero_context(@user)
-        @user.stub(:with_vero_context).and_return(context)
+        allow(@user).to receive(:with_vero_context).and_return(context)
 
-        RestClient.stub(:post).and_return(200)
+        allow(RestClient).to receive(:post).and_return(200)
 
-        Vero::Api::Events.stub(:track!).and_return(200)
-        Vero::Api::Events.should_receive(:track!).with(@request_params, context)
-        @user.track!(@request_params[:event_name], @request_params[:data]).should == 200
+        allow(Vero::Api::Events).to receive(:track!).and_return(200)
+        expect(Vero::Api::Events).to receive(:track!).with(@request_params, context)
+        expect(@user.track!(@request_params[:event_name], @request_params[:data])).to eq(200)
 
-        Vero::Api::Events.stub(:track!).and_return(200)
-        Vero::Api::Events.should_receive(:track!).with(@request_params.merge(:data => {}), context)
-        @user.track!(@request_params[:event_name]).should == 200
+        allow(Vero::Api::Events).to receive(:track!).and_return(200)
+        expect(Vero::Api::Events).to receive(:track!).with(@request_params.merge(:data => {}), context)
+        expect(@user.track!(@request_params[:event_name])).to eq(200)
       end
 
       context 'when set to be async' do
         before do
           @context = vero_context(@user, true, true)
-          @user.stub(:with_vero_context).and_return(@context)
+          allow(@user).to receive(:with_vero_context).and_return(@context)
         end
 
         context 'not using Ruby 1.8.7' do
           before { stub_const('RUBY_VERSION', '1.9.3') }
 
           it 'sends' do
-            @user.track!(@request_params[:event_name], @request_params[:data]).should be_nil
-            @user.track!(@request_params[:event_name]).should be_nil
+            expect(@user.track!(@request_params[:event_name], @request_params[:data])).to be_nil
+            expect(@user.track!(@request_params[:event_name])).to be_nil
           end
         end
       end
@@ -105,25 +105,25 @@ describe Vero::Trackable do
 
       it "should send an `identify` request when async is set to false" do
         context = vero_context(@user)
-        @user.stub(:with_vero_context).and_return(context)
+        allow(@user).to receive(:with_vero_context).and_return(context)
 
-        Vero::Api::Users.stub(:track!).and_return(200)
-        Vero::Api::Users.should_receive(:track!).with(@request_params, context)
+        allow(Vero::Api::Users).to receive(:track!).and_return(200)
+        expect(Vero::Api::Users).to receive(:track!).with(@request_params, context)
 
-        @user.identify!.should == 200
+        expect(@user.identify!).to eq(200)
       end
 
       context 'when set to use async' do
         before do
           @context = vero_context(@user, false, true)
-          @user.stub(:with_vero_context).and_return(@context)
+          allow(@user).to receive(:with_vero_context).and_return(@context)
         end
 
         context 'and not using Ruby 1.8.7' do
           before { stub_const('RUBY_VERSION', '1.9.3') }
 
           it 'sends' do
-            @user.identify!.should be_nil
+            expect(@user.identify!).to be_nil
           end
         end
       end
@@ -143,18 +143,18 @@ describe Vero::Trackable do
         context = Vero::Context.new(Vero::App.default_context)
         context.subject = @user
 
-        @user.stub(:with_vero_context).and_return(context)
+        allow(@user).to receive(:with_vero_context).and_return(context)
 
-        Vero::Api::Users.stub(:edit_user!).and_return(200)
-        Vero::Api::Users.should_receive(:edit_user!).with(@request_params, context)
+        allow(Vero::Api::Users).to receive(:edit_user!).and_return(200)
+        expect(Vero::Api::Users).to receive(:edit_user!).with(@request_params, context)
 
-        @user.with_vero_context.update_user!.should == 200
+        expect(@user.with_vero_context.update_user!).to eq(200)
       end
 
       context 'when set to use async' do
         before do
           @context = vero_context(@user, false, true)
-          @user.stub(:with_vero_context).and_return(@context)
+          allow(@user).to receive(:with_vero_context).and_return(@context)
         end
 
         context 'and using Ruby 1.8.7' do
@@ -170,7 +170,7 @@ describe Vero::Trackable do
           before { stub_const('RUBY_VERSION', '1.9.3') }
 
           it 'sends' do
-            @user.with_vero_context.update_user!.should be_nil
+            expect(@user.with_vero_context.update_user!).to be_nil
           end
         end
       end
@@ -192,12 +192,12 @@ describe Vero::Trackable do
         context.subject = @user
         context.config.async = false
 
-        @user.stub(:with_vero_context).and_return(context)
+        allow(@user).to receive(:with_vero_context).and_return(context)
 
-        Vero::Api::Users.stub(:edit_user_tags!).and_return(200)
-        Vero::Api::Users.should_receive(:edit_user_tags!).with(@request_params, context)
+        allow(Vero::Api::Users).to receive(:edit_user_tags!).and_return(200)
+        expect(Vero::Api::Users).to receive(:edit_user_tags!).with(@request_params, context)
 
-        @user.with_vero_context.update_user_tags!.should == 200
+        expect(@user.with_vero_context.update_user_tags!).to eq(200)
       end
 
       if RUBY_VERSION =~ /1\.9\./
@@ -206,9 +206,9 @@ describe Vero::Trackable do
           context.subject = @user
           context.config.async = true
 
-          @user.stub(:with_vero_context).and_return(context)
+          allow(@user).to receive(:with_vero_context).and_return(context)
 
-          @user.with_vero_context.update_user_tags!.should be_nil
+          expect(@user.with_vero_context.update_user_tags!).to be_nil
         end
       end
     end
@@ -227,25 +227,25 @@ describe Vero::Trackable do
         context.subject = @user
         context.config.async = false
 
-        @user.stub(:with_vero_context).and_return(context)
+        allow(@user).to receive(:with_vero_context).and_return(context)
 
-        Vero::Api::Users.stub(:unsubscribe!).and_return(200)
-        Vero::Api::Users.should_receive(:unsubscribe!).with(@request_params, context)
+        allow(Vero::Api::Users).to receive(:unsubscribe!).and_return(200)
+        expect(Vero::Api::Users).to receive(:unsubscribe!).with(@request_params, context)
 
-        @user.with_vero_context.unsubscribe!.should == 200
+        expect(@user.with_vero_context.unsubscribe!).to eq(200)
       end
 
       context 'when using async' do
         before do
           @context = vero_context(@user, false, true)
-          @user.stub(:with_vero_context).and_return(@context)
+          allow(@user).to receive(:with_vero_context).and_return(@context)
         end
 
         context 'and using Ruby 1.9.3' do
           before { stub_const('RUBY_VERSION', '1.9.3') }
 
           it 'sends' do
-            @user.with_vero_context.unsubscribe!.should be_nil
+            expect(@user.with_vero_context.unsubscribe!).to be_nil
           end
         end
       end
@@ -256,18 +256,18 @@ describe Vero::Trackable do
 
       it "should build an array of trackable params" do
         User.trackable :email, :age
-        User.trackable_map.should == [:email, :age]
+        expect(User.trackable_map).to eq([:email, :age])
       end
 
       it "should append new trackable items to an existing trackable map" do
         User.trackable :email, :age
         User.trackable :hair_colour
-        User.trackable_map.should == [:email, :age, :hair_colour]
+        expect(User.trackable_map).to eq([:email, :age, :hair_colour])
       end
 
       it "should append an extra's hash to the trackable map" do
         User.trackable :email, {:extras => :properties}
-        User.trackable_map.should == [:email, {:extras => :properties}]
+        expect(User.trackable_map).to eq([:email, {:extras => :properties}])
       end
     end
 
@@ -279,54 +279,54 @@ describe Vero::Trackable do
 
       it "should return a hash of all values mapped by trackable" do
         user = User.new
-        user.to_vero.should == {:email => 'durkster@gmail.com', :age => 20, :_user_type => "User"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :age => 20, :_user_type => "User"})
 
         user = UserWithoutEmail.new
-        user.to_vero.should == {:email => 'durkster@gmail.com', :age => 20, :_user_type => "UserWithoutEmail"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :age => 20, :_user_type => "UserWithoutEmail"})
 
         user = UserWithEmailAddress.new
-        user.to_vero.should == {:email => 'durkster@gmail.com', :age => 20, :_user_type => "UserWithEmailAddress"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :age => 20, :_user_type => "UserWithEmailAddress"})
 
         user = UserWithoutInterface.new
-        user.to_vero.should == {:email => 'durkster@gmail.com', :age => 20, :_user_type => "UserWithoutInterface"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :age => 20, :_user_type => "UserWithoutInterface"})
 
         user = UserWithNilAttributes.new
-        user.to_vero.should == {:email => 'durkster@gmail.com', :_user_type => "UserWithNilAttributes"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :_user_type => "UserWithNilAttributes"})
       end
 
       it "should take into account any defined extras" do
         user = UserWithExtras.new
         user.properties = nil
-        user.to_vero.should == {:email => 'durkster@gmail.com', :_user_type => "UserWithExtras"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :_user_type => "UserWithExtras"})
 
         user.properties = "test"
-        user.to_vero.should == {:email => 'durkster@gmail.com', :_user_type => "UserWithExtras"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :_user_type => "UserWithExtras"})
 
         user.properties = {}
-        user.to_vero.should == {:email => 'durkster@gmail.com', :_user_type => "UserWithExtras"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :_user_type => "UserWithExtras"})
 
         user.properties = {
           :age => 20,
           :gender => "female"
         }
-        user.to_vero.should == {:email => 'durkster@gmail.com', :age => 20, :gender => "female", :_user_type => "UserWithExtras"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :age => 20, :gender => "female", :_user_type => "UserWithExtras"})
 
         user = UserWithPrivateExtras.new
-        user.to_vero.should == {:email => 'durkster@gmail.com', :age => 26, :_user_type => "UserWithPrivateExtras"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :age => 26, :_user_type => "UserWithPrivateExtras"})
       end
 
       it "should allow extras to be provided instead :id or :email" do
         user = UserWithOnlyExtras.new
         user.properties = {:email => user.email}
-        user.to_vero.should == {:email => 'durkster@gmail.com', :_user_type => "UserWithOnlyExtras"}
+        expect(user.to_vero).to eq({:email => 'durkster@gmail.com', :_user_type => "UserWithOnlyExtras"})
       end
     end
 
     describe :with_vero_context do
       it "should be able to change contexts" do
         user = User.new
-        user.with_default_vero_context.config.config_params.should == {:api_key=>"abcd1234", :secret=>"efgh5678"}
-        user.with_vero_context({:api_key => "boom", :secret => "tish"}).config.config_params.should == {:api_key=>"boom", :secret=>"tish"}
+        expect(user.with_default_vero_context.config.config_params).to eq({:api_key=>"abcd1234", :secret=>"efgh5678"})
+        expect(user.with_vero_context({:api_key => "boom", :secret => "tish"}).config.config_params).to eq({:api_key=>"boom", :secret=>"tish"})
       end
     end
 
@@ -344,12 +344,12 @@ describe Vero::Trackable do
 
       context = Vero::Context.new(Vero::App.default_context)
       context.subject = user
-      context.stub(:post_now).and_return(200)
+      allow(context).to receive(:post_now).and_return(200)
 
-      user.stub(:with_vero_context).and_return(context)
+      allow(user).to receive(:with_vero_context).and_return(context)
 
-      RestClient.stub(:post).and_return(200)
-      user.vero_track(request_params[:event_name], request_params[:data]).should == 200
+      allow(RestClient).to receive(:post).and_return(200)
+      expect(user.vero_track(request_params[:event_name], request_params[:data])).to eq(200)
     end
   end
 end

--- a/spec/lib/trackable_spec.rb
+++ b/spec/lib/trackable_spec.rb
@@ -16,7 +16,7 @@ describe Vero::Trackable do
       :event_name => 'test_event',
       :auth_token => 'YWJjZDEyMzQ6ZWZnaDU2Nzg=',
       :identity => {:email => 'durkster@gmail.com', :age => 20, :_user_type => "User"},
-      :data => { :test => 1 },
+      :data => {:test => 1},
       :development_mode => true
     }
     @url = "https://api.getvero.com/api/v1/track.json"
@@ -28,10 +28,10 @@ describe Vero::Trackable do
   context "the gem has not been configured" do
     before { Vero::App.reset! }
     it "should raise an error when API requests are made" do
-      expect { @user.track(@request_params[:event_name], @request_params[:data]) }.to raise_error
+      expect { @user.track(@request_params[:event_name], @request_params[:data]) }.to raise_error(RuntimeError)
 
       allow(@user).to receive(:post_later).and_return('success')
-      expect { @user.identity! }.to raise_error
+      expect { @user.identity! }.to raise_error(NoMethodError)
     end
   end
 
@@ -56,9 +56,9 @@ describe Vero::Trackable do
       end
 
       it "should not send a track request when the required parameters are invalid" do
-        expect { @user.track!(nil) }.to raise_error
-        expect { @user.track!('') }.to raise_error
-        expect { @user.track!('test', '') }.to raise_error
+        expect { @user.track!(nil) }.to raise_error(ArgumentError)
+        expect { @user.track!('') }.to raise_error(ArgumentError)
+        expect { @user.track!('test', '') }.to raise_error(ArgumentError)
       end
 
       it "should send a `track!` request when async is set to false" do
@@ -162,7 +162,7 @@ describe Vero::Trackable do
 
           it 'raises an error' do
             @context.config.disabled = false
-            expect { @user.with_vero_context.update_user! }.to raise_error
+            expect { @user.with_vero_context.update_user! }.to raise_error(RuntimeError)
           end
         end
 

--- a/spec/lib/view_helpers_spec.rb
+++ b/spec/lib/view_helpers_spec.rb
@@ -17,10 +17,10 @@ describe Vero::ViewHelpers::Javascript do
   subject { Vero::ViewHelpers::Javascript }
   describe :vero_javascript_tag do
     it "should return an empty string if Vero::App is not properly configured" do
-      subject.vero_javascript_tag.should == ""
+      expect(subject.vero_javascript_tag).to eq("")
 
       Vero::App.init {}
-      subject.vero_javascript_tag.should == ""
+      expect(subject.vero_javascript_tag).to eq("")
     end
 
     context "Vero::App has been properly configured" do
@@ -38,7 +38,7 @@ describe Vero::ViewHelpers::Javascript do
 
       it "should return a properly formatted javascript snippet" do
         result = "<script type=\"text/javascript\">var _veroq = _veroq || [];setTimeout(function(){if(typeof window.Semblance==\"undefined\"){console.log(\"Vero did not load in time.\");for(var i=0;i<_veroq.length;i++){a=_veroq[i];if(a.length==3&&typeof a[2]==\"function\")a[2](null,false);}}},3000);_veroq.push(['init', {\"api_key\": \"#{@api_key}\", \"secret\": \"#{@api_secret}\"}]);(function() {var ve = document.createElement('script'); ve.type = 'text/javascript'; ve.async = true; ve.src = '//getvero.com/assets/m.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ve, s);})();</script>"
-        subject.vero_javascript_tag.should == result
+        expect(subject.vero_javascript_tag).to eq(result)
       end
     end
   end

--- a/spec/support/base_config_shared_examples.rb
+++ b/spec/support/base_config_shared_examples.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples "a Vero wrapper" do
+  it "should inherit from Vero::Api::Workers::BaseCaller" do
+    expect(subject).to be_a(Vero::Api::Workers::BaseAPI)
+  end
+
+  it "should map to current version of Vero API" do
+    expect(subject.send(:url)).to eq("https://api.getvero.com#{end_point}")
+  end
+end


### PR DESCRIPTION
- Rspec 3.x uses a different syntax (to 2.x): `subject.should be_true` -> `expect(subject).to be_true`.
- Added 2.2.0 to the list of Ruby versions to test against.
- Adopted `let`s and shared examples more.

Let me know what you think :-).