### PR TITLE
Configuration needs not being checked in test environment

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,8 +27,8 @@ following:
         config.api_key = "Your Production API key goes here"
         config.secret = "Your Production API secret goes here"
       else
-        config.api_key = "Your Test API key goes here"
-        config.secret = "Your Test API secret goes here"
+        config.api_key = "Your Development API key goes here"
+        config.secret = "Your Development API secret goes here"
       end
     end
 
@@ -47,7 +47,7 @@ We recommend that you select one of the supported queue-based alternatives:
 **Note:** If you're using Mongoid with DelayedJob, you must add
 `gem "delayed_job_mongoid"` to your Gemfile.
 
-Finally, if you wish to disable vero requests when running your automated tests,
+Finally, if you wish to disable Vero requests when running your automated tests,
 add the following line to your initializer:
 
     config.disabled = Rails.env.test?

--- a/lib/vero/api.rb
+++ b/lib/vero/api.rb
@@ -12,12 +12,10 @@ module Vero
       end
 
       def run_api(api_klass, options)
+        return if config.disabled
         validate_configured!
         options.merge!(config.request_params)
-
-        unless config.disabled
-          Vero::Sender.send(api_klass, config.async, config.domain, options)
-        end
+        Vero::Sender.send(api_klass, config.async, config.domain, options)
       end
 
       protected

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -98,4 +98,14 @@ describe Vero::Config do
       expect(config.request_params[:development_mode]).to be(false)
     end
   end
+
+  describe :test_mode do
+    it 'should not raise error even though not configured properly' do
+      input = {:event_name => "test_event"}
+      mock_context = Vero::Context.new
+      allow(mock_context.config).to receive(:configured?).and_return(false)
+
+      expect { Vero::Api::Events.track!(input) }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
IMO I don't think people need to provide any API key & secret in `Rails.env.test`s, the gem also needs not checking for these configurations.

Wording in the README is also revised to reflect this.