### PR TITLE
Locking sucker_punch dependency to 1.5.1

### DIFF
--- a/lib/vero/version.rb
+++ b/lib/vero/version.rb
@@ -1,3 +1,3 @@
 module Vero
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end

--- a/vero.gemspec
+++ b/vero.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     [:development, 'resque'],
     [:runtime,     'json'],
     [:runtime,     'rest-client'],
-    [:runtime,     'sucker_punch', '~> 1.5']
+    [:runtime,     'sucker_punch', '1.5.1']
   ]
 
   s.files         = Dir['**/*']


### PR DESCRIPTION
Please see: https://github.com/brandonhilkert/sucker_punch/commit/579b5d9110334724ccd464d3a8ac794c9d36b1a6.

`celluloid` 0.16.1 gives red builds everywhere :).