### PR TITLE
Add way to define Sidekiq sender class

### DIFF
--- a/lib/vero.rb
+++ b/lib/vero.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'rest-client'
 require 'vero/utility/ext'
 

--- a/lib/vero/api/base_api.rb
+++ b/lib/vero/api/base_api.rb
@@ -1,6 +1,3 @@
-require 'json'
-require 'rest-client'
-
 module Vero
   module Api
     module Workers

--- a/lib/vero/config.rb
+++ b/lib/vero/config.rb
@@ -3,10 +3,12 @@ require 'base64'
 module Vero
   class Config
     attr_writer :domain
-    attr_accessor :api_key, :secret, :development_mode, :async, :disabled, :logging
+    attr_accessor :api_key, :secret, :development_mode, :async, :disabled
+    attr_accessor :logging, :sender_class
 
     def self.available_attributes
-      [:api_key, :secret, :development_mode, :async, :disabled, :logging, :domain]
+      [:api_key, :secret, :development_mode, :async, :disabled, :logging,
+        :domain, :sender_class]
     end
 
     def initialize

--- a/lib/vero/sender.rb
+++ b/lib/vero/sender.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module Vero
   class SenderHash < ::Hash
     def [](key)
@@ -39,7 +37,7 @@ module Vero
       else
         self.senders[false]
       end
-      
+
       (sender_class.new).call(api_class, domain, options)
     rescue => e
       options_s = JSON.dump(options)

--- a/lib/vero/senders/base.rb
+++ b/lib/vero/senders/base.rb
@@ -1,12 +1,9 @@
-require 'json'
-
 module Vero
   module Senders
     class Base
       def call(api_class, domain, options)
         response = api_class.perform(domain, options)
-        options_s = JSON.dump(options)
-        Vero::App.log(self, "method: #{api_class.name}, options: #{options_s}, response: job performed")
+        Vero::App.log(self, "method: #{api_class.name}, options: #{JSON.dump(options)}, response: job performed")
         response
       end
     end

--- a/lib/vero/senders/delayed_job.rb
+++ b/lib/vero/senders/delayed_job.rb
@@ -1,4 +1,3 @@
-require 'json'
 require 'delayed_job'
 
 module Vero
@@ -6,8 +5,7 @@ module Vero
     class DelayedJob
       def call(api_class, domain, options)
         response = ::Delayed::Job.enqueue api_class.new(domain, options)
-        options_s = JSON.dump(options)
-        Vero::App.log(self, "method: #{api_class.name}, options: #{options_s}, response: delayed job queued")
+        Vero::App.log(self, "method: #{api_class.name}, options: #{JSON.dump(options)}, response: delayed job queued")
         response
       rescue => e
         if e.message == "Could not find table 'delayed_jobs'"

--- a/lib/vero/senders/resque.rb
+++ b/lib/vero/senders/resque.rb
@@ -1,19 +1,16 @@
-require 'json'
 require 'resque'
 
 module Vero
   class ResqueWorker
     @queue = :vero
 
-    def self.perform(api_class_name, domain, options)
-      api_class = eval(api_class_name)
+    def self.perform(api_class, domain, options)
+      api_class = eval(api_class.to_s)
       new_options = {}
-      options.each do |k,v|
-        new_options[k.to_sym] = v
-      end
+      options.each { |k,v| new_options[k.to_sym] = v }
 
       api_class.new(domain, new_options).perform
-      Vero::App.log(self, "method: #{api_class.name}, options: #{options.to_json}, response: resque job queued")
+      Vero::App.log(self, "method: #{api_class.name}, options: #{JSON.dump(options)}, response: resque job queued")
     end
   end
 

--- a/lib/vero/senders/sidekiq.rb
+++ b/lib/vero/senders/sidekiq.rb
@@ -6,17 +6,31 @@ module Vero
     include ::Sidekiq::Worker
 
     def perform(api_class, domain, options)
-      api_class.constantize.new(domain, options).perform
-      Vero::App.log(self, "method: #{api_class}, options: #{options.to_json}, response: sidekiq job queued")
+      send_to_vero(api_class, domain, options)
+    end
+
+    protected
+
+    def send_to_vero(api_class, domain, options)
+      api_klass(api_class).new(domain, options).perform
+      Vero::App.log(self, "method: #{api_class}, options: #{options.to_json}, response: sidekiq job performed")
+    end
+
+    def api_klass(api_class)
+      api_class.constantize
     end
   end
 
   module Senders
     class Sidekiq
       def call(api_class, domain, options)
-        response = ::Vero::SidekiqWorker.perform_async(api_class.to_s, domain, options)
+        response = sender_class.perform_async(api_class.to_s, domain, options)
         Vero::App.log(self, "method: #{api_class.name}, options: #{options.to_json}, response: sidekiq job queued")
         response
+      end
+
+      def sender_class
+        ::Vero::SidekiqWorker
       end
     end
   end

--- a/lib/vero/senders/sidekiq.rb
+++ b/lib/vero/senders/sidekiq.rb
@@ -1,4 +1,3 @@
-require 'json'
 require 'sidekiq'
 
 module Vero
@@ -13,11 +12,11 @@ module Vero
 
     def send_to_vero(api_class, domain, options)
       api_klass(api_class).new(domain, options).perform
-      Vero::App.log(self, "method: #{api_class}, options: #{options.to_json}, response: sidekiq job performed")
+      Vero::App.log(self, "method: #{api_class}, options: #{JSON.dump(options)}, response: sidekiq job performed")
     end
 
     def api_klass(api_class)
-      api_class.constantize
+      eval(api_class.to_s)
     end
   end
 
@@ -25,7 +24,7 @@ module Vero
     class Sidekiq
       def call(api_class, domain, options)
         response = sender_class.perform_async(api_class.to_s, domain, options)
-        Vero::App.log(self, "method: #{api_class.name}, options: #{options.to_json}, response: sidekiq job queued")
+        Vero::App.log(self, "method: #{api_class.name}, options: #{JSON.dump(options)}, response: sidekiq job queued")
         response
       end
 

--- a/lib/vero/senders/sidekiq.rb
+++ b/lib/vero/senders/sidekiq.rb
@@ -29,7 +29,13 @@ module Vero
       end
 
       def sender_class
-        ::Vero::SidekiqWorker
+        klass = Vero::App.default_context.config.sender_class
+
+        if klass && klass.new.is_a?(::Sidekiq::Worker)
+          klass
+        else
+          Vero::SidekiqWorker
+        end
       end
     end
   end

--- a/lib/vero/senders/thread.rb
+++ b/lib/vero/senders/thread.rb
@@ -1,4 +1,3 @@
-require 'json'
 require 'sucker_punch'
 
 module Vero
@@ -11,9 +10,9 @@ module Vero
 
       begin
         api_class.new(domain, new_options).perform
-        Vero::App.log(self, "method: #{api_class.name}, options: #{options.to_json}, response: job performed")
+        Vero::App.log(self, "method: #{api_class.name}, options: #{JSON.dump(options)}, response: job performed")
       rescue => e
-        Vero::App.log(self, "method: #{api_class.name}, options: #{options.to_json}, response: #{e.message}")
+        Vero::App.log(self, "method: #{api_class.name}, options: #{JSON.dump(options)}, response: #{e.message}")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'vero'
 require 'sucker_punch/testing/inline'
+# require 'byebug'
 
 Dir[::File.expand_path('../support/**/*.rb',  __FILE__)].each { |f| require f }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'vero'
-require 'json'
 require 'sucker_punch/testing/inline'
 
 Dir[::File.expand_path('../support/**/*.rb',  __FILE__)].each { |f| require f }

--- a/vero.gemspec
+++ b/vero.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.authors  = ['James Lamont']
 
   dependencies = [
+    [:development, 'byebug'],
     [:development, 'rails', "~> 3.0"],
     [:development, 'rspec'],
     [:development, 'delayed_job', "~> 3.0.0"],


### PR DESCRIPTION
This is one possible solution to #51 and #54. Essentially you can define your own SidekiqWorker class to send API requests to Vero.

Something like this...

```ruby
class MyVeroSidekiqWorker << Vero::SidekiqWorker
   sidekiq_options retry: 2, queue: 'another_queue'
   sidekiq_retry_in { |count| 60 }
end
```

and in `vero.rb`

```ruby
Vero::App.init do |config|
   # ...
   config.sender_class = MyVeroSidekiqWorker
end
```

What do you think @damienbrz, @shaneog, @lemboy, @criticerz?