### PR TITLE
Make sucker_punch optional

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,8 +42,8 @@ You will be able to find your API key and secret by logging into Vero
 ([sign up](http://getvero.com) if you haven't already) and clicking the
 'Your Account' link at the top of the page then select 'API Keys'.
 
-By default, events are sent asynchronously using a background thread.
-We recommend that you select one of the supported queue-based alternatives:
+By default, events are sent synchronously.
+We recommend that you select one of the supported background thread/queue-based alternatives:
 
 ```ruby
 config.async = :none            # Synchronously

--- a/lib/vero.rb
+++ b/lib/vero.rb
@@ -9,6 +9,7 @@ module Vero
   autoload :Trackable,            'vero/trackable'
   autoload :DSL,                  'vero/dsl'
   autoload :Sender,               'vero/sender'
+  autoload :SuckerPunchWorker,    'vero/senders/sucker_punch'
   autoload :ResqueWorker,         'vero/senders/resque'
   autoload :SidekiqWorker,        'vero/senders/sidekiq'
 
@@ -40,7 +41,7 @@ module Vero
     autoload :Resque,             'vero/senders/resque'
     autoload :Sidekiq,            'vero/senders/sidekiq'
     autoload :Invalid,            'vero/senders/invalid'
-    autoload :Thread,             'vero/senders/thread'
+    autoload :SuckerPunch,         'vero/senders/sucker_punch'
   end
 
   module Utility

--- a/lib/vero/sender.rb
+++ b/lib/vero/sender.rb
@@ -19,14 +19,12 @@ module Vero
       t.merge!({
         true          => Vero::Senders::Invalid,
         false         => Vero::Senders::Base,
-        :none         => Vero::Senders::Base,
-        :thread       => Vero::Senders::Invalid
+        :none         => Vero::Senders::Base
       })
 
       if RUBY_VERSION !~ /1\.8\./
         t.merge!(
-          true        => Vero::Senders::Thread,
-          :thread     => Vero::Senders::Thread
+          true        => Vero::Senders::Base
         )
       end
 
@@ -39,7 +37,7 @@ module Vero
       else
         self.senders[false]
       end
-      
+
       (sender_class.new).call(api_class, domain, options)
     rescue => e
       options_s = JSON.dump(options)

--- a/lib/vero/senders/sucker_punch.rb
+++ b/lib/vero/senders/sucker_punch.rb
@@ -19,7 +19,7 @@ module Vero
   end
 
   module Senders
-    class Thread
+    class SuckerPunch
       def call(api_class, domain, options)
         Vero::SuckerPunchWorker.new.async.perform(api_class, domain, options)
       end

--- a/spec/lib/sender_spec.rb
+++ b/spec/lib/sender_spec.rb
@@ -13,18 +13,18 @@ describe Vero::Sender do
         stub_const('RUBY_VERSION', '1.9.3')
       end
 
-      it "should have a default set of senders (true, false, none, thread)" do
+      it "should have a default set of senders (true, false, none)" do
         expect(subject.senders).to eq({
-          true          => Vero::Senders::Thread,
+          true          => Vero::Senders::Base,
           false         => Vero::Senders::Base,
           :none         => Vero::Senders::Base,
-          :thread       => Vero::Senders::Thread,
         })
       end
     end
 
     it "should automatically find senders that are not defined" do
       expect(subject.senders[:delayed_job]).to  eq(Vero::Senders::DelayedJob)
+      expect(subject.senders[:sucker_punch]).to eq(Vero::Senders::SuckerPunch)
       expect(subject.senders[:resque]).to       eq(Vero::Senders::Resque)
       expect(subject.senders[:sidekiq]).to      eq(Vero::Senders::Sidekiq)
       expect(subject.senders[:invalid]).to      eq(Vero::Senders::Invalid)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'bundler/setup'
 require 'vero'
 require 'json'
-require 'sucker_punch/testing/inline'
 
 Dir[::File.expand_path('../support/**/*.rb',  __FILE__)].each { |f| require f }
 

--- a/vero.gemspec
+++ b/vero.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
     [:development, 'delayed_job_active_record'],
     [:development, 'resque'],
     [:development, 'sidekiq', "~> 3.5.1"],
+    [:development, 'sucker_punch', '~> 1.6.0'],
     [:runtime,     'json'],
-    [:runtime,     'rest-client'],
-    [:runtime,     'sucker_punch', '~> 1.6.0']
+    [:runtime,     'rest-client']
   ]
 
   s.files         = Dir['**/*']


### PR DESCRIPTION
Due to some previous issues with `sidekiq` and `sucker_punch`, we've removed `sucker_punch` as a required dependency and made it optional. 

However, this means that the user **must explicitly choose** to send the events asynchronously. For us it makes this gem more flexible, but it's obviously not backwards compatible with the initial design decision _(defaulting to use `sucker_punch`)_.

We have been using this in production for several months, with no issues.
