### PR TITLE
Updated to RSpec 3 syntax.

### DIFF
--- a/spec/lib/api/users/resubscribe_api_spec.rb
+++ b/spec/lib/api/users/resubscribe_api_spec.rb
@@ -21,8 +21,12 @@ describe Vero::Api::Workers::Users::ResubscribeAPI do
 
   describe :request do
     it "should send a request to the Vero API" do
-      RestClient.should_receive(:post).with("https://api.getvero.com/api/v2/users/resubscribe.json", {:auth_token => 'abcd', :id => '1234'})
-      RestClient.stub(:post).and_return(200)
+      expect(RestClient).to(
+        receive(:post).
+        with('https://api.getvero.com/api/v2/users/resubscribe.json', { auth_token: 'abcd', id: '1234' })
+      )
+      allow(RestClient).to receive(:post).and_return(200)
+
       subject.send(:request)
     end
   end

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -83,7 +83,10 @@ describe Vero::Api::Users do
       let(:input) { {:email => "james@getvero"} }
 
       specify do
-        Vero::Sender.should_receive(:send).with(Vero::Api::Workers::Users::ResubscribeAPI, true, "https://api.getvero.com", expected)
+        expect(Vero::Sender).to(
+          receive(:send).
+          with(Vero::Api::Workers::Users::ResubscribeAPI, true, 'https://api.getvero.com', expected)
+        )
         subject.resubscribe!(input)
       end
     end

--- a/spec/lib/senders/sidekiq_spec.rb
+++ b/spec/lib/senders/sidekiq_spec.rb
@@ -4,7 +4,11 @@ describe Vero::Senders::Sidekiq do
   subject { Vero::Senders::Sidekiq.new }
   describe :call do
     it "should perform_async a Vero::SidekiqWorker" do
-      Vero::SidekiqWorker.should_receive(:perform_async).with('Vero::Api::Workers::Events::TrackAPI', "abc", {:test => "abc"}).once
+      expect(Vero::SidekiqWorker).to(
+        receive(:perform_async).
+        with('Vero::Api::Workers::Events::TrackAPI', 'abc', { test: 'abc' }).
+        once
+      )
       subject.call(Vero::Api::Workers::Events::TrackAPI, "abc", {:test => "abc"})
     end
   end
@@ -15,9 +19,10 @@ describe Vero::SidekiqWorker do
   describe :perform do
     it "should call the api method" do
       mock_api = double(Vero::Api::Workers::Events::TrackAPI)
-      mock_api.should_receive(:perform).once
-      Vero::Api::Workers::Events::TrackAPI.stub(:new).and_return(mock_api)
-      Vero::Api::Workers::Events::TrackAPI.should_receive(:new).with("abc", {:test => "abc"}).once
+      expect(mock_api).to receive(:perform).once
+
+      allow(Vero::Api::Workers::Events::TrackAPI).to receive(:new).and_return(mock_api)
+      expect(Vero::Api::Workers::Events::TrackAPI).to receive(:new).with('abc', { test: 'abc' }).once
 
       subject.perform('Vero::Api::Workers::Events::TrackAPI', "abc", {:test => "abc"})
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,11 @@ require 'json'
 Dir[::File.expand_path('../support/**/*.rb',  __FILE__)].each { |f| require f }
 
 RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = [:expect]
+  end
+
+  config.raise_errors_for_deprecations!
 end
 
 def stub_env(new_env, &block)


### PR DESCRIPTION
This PR moves to RSpec 3 syntax, replacing `should_receive` with `expect` and `allow`.