### PR TITLE
Follow up to "Make sucker_punch optional" #59

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,11 +43,12 @@ You will be able to find your API key and secret by logging into Vero
 'Your Account' link at the top of the page then select 'API Keys'.
 
 By default, events are sent synchronously.
-We recommend that you select one of the supported background thread/queue-based alternatives:
+We recommend that you select one of the supported background thread/queue-based alternatives and add their
+respective gem to your Gemfile:
 
 ```ruby
 config.async = :none            # Synchronously
-config.async = :thread          # Background thread (default)
+config.async = :sucker_punch    # SuckerPunch
 config.async = :delayed_job     # DelayedJob
 config.async = :sidekiq         # Sidekiq
 config.async = :resque          # Resque (recommended)

--- a/lib/vero/sender.rb
+++ b/lib/vero/sender.rb
@@ -19,16 +19,10 @@ module Vero
       t = Vero::SenderHash.new
 
       t.merge!({
-                 true => Vero::Senders::Invalid,
+                 true => Vero::Senders::Base,
                  false => Vero::Senders::Base,
                  :none => Vero::Senders::Base
                })
-
-      if RUBY_VERSION !~ /1\.8\./
-        t.merge!(
-          true => Vero::Senders::Base
-        )
-      end
 
       t
     end

--- a/lib/vero/sender.rb
+++ b/lib/vero/sender.rb
@@ -3,34 +3,25 @@
 require 'json'
 
 module Vero
-  class SenderHash < ::Hash
+  class SenderLookup
     def [](key)
-      if key?(key)
-        super
-      else
-        klass_name = key.to_s.split('_').map(&:capitalize).join
+      klass_name = key.to_s.split('_').map(&:capitalize).join
+
+      if Vero::Senders.const_defined?(klass_name)
         Vero::Senders.const_get(klass_name)
+      else
+        Vero::Senders::Base
       end
     end
   end
 
   class Sender
     def self.senders
-      t = Vero::SenderHash.new
-
-      t.merge!({
-                 true => Vero::Senders::Base,
-                 false => Vero::Senders::Base,
-                 :none => Vero::Senders::Base
-               })
-
-      t
+      @senders ||= Vero::SenderLookup.new
     end
 
     def self.send(api_class, sender_strategy, domain, options)
-      sender_class = senders[sender_strategy] || senders[false]
-
-      sender_class.new.call(api_class, domain, options)
+      senders[sender_strategy].new.call(api_class, domain, options)
     rescue StandardError => e
       options_s = JSON.dump(options)
       Vero::App.log(new, "method: #{api_class.name}, options: #{options_s}, error: #{e.message}")

--- a/spec/lib/sender_spec.rb
+++ b/spec/lib/sender_spec.rb
@@ -6,25 +6,17 @@ describe Vero::Sender do
   subject { Vero::Sender }
 
   describe '.senders' do
-    it 'should be a Hash' do
-      expect(subject.senders).to be_a(Hash)
-    end
-
-    it 'should have a default set of senders (true, false, none)' do
-      expect(subject.senders).to eq({
-                                      true => Vero::Senders::Base,
-                                      false => Vero::Senders::Base,
-                                      :none => Vero::Senders::Base
-                                    })
-    end
-
     it 'should automatically find senders that are not defined' do
-      expect(subject.senders[:delayed_job]).to  eq(Vero::Senders::DelayedJob)
+      expect(subject.senders[:delayed_job]).to eq(Vero::Senders::DelayedJob)
       expect(subject.senders[:sucker_punch]).to eq(Vero::Senders::SuckerPunch)
-      expect(subject.senders[:resque]).to       eq(Vero::Senders::Resque)
-      expect(subject.senders[:sidekiq]).to      eq(Vero::Senders::Sidekiq)
-      expect(subject.senders[:invalid]).to      eq(Vero::Senders::Invalid)
-      expect(subject.senders[:none]).to         eq(Vero::Senders::Base)
+      expect(subject.senders[:resque]).to eq(Vero::Senders::Resque)
+      expect(subject.senders[:sidekiq]).to eq(Vero::Senders::Sidekiq)
+      expect(subject.senders[:invalid]).to eq(Vero::Senders::Invalid)
+      expect(subject.senders[:none]).to eq(Vero::Senders::Base)
+    end
+
+    it 'should fallback to Vero::Senders::Base' do
+      expect(subject.senders[:unsupported_sender]).to eq(Vero::Senders::Base)
     end
   end
 end

--- a/spec/lib/sender_spec.rb
+++ b/spec/lib/sender_spec.rb
@@ -10,18 +10,12 @@ describe Vero::Sender do
       expect(subject.senders).to be_a(Hash)
     end
 
-    context 'when using Ruby with verion greater than 1.8.7' do
-      before do
-        stub_const('RUBY_VERSION', '1.9.3')
-      end
-
-      it 'should have a default set of senders (true, false, none)' do
-        expect(subject.senders).to eq({
-                                        true => Vero::Senders::Base,
-                                        false => Vero::Senders::Base,
-                                        :none => Vero::Senders::Base
-                                      })
-      end
+    it 'should have a default set of senders (true, false, none)' do
+      expect(subject.senders).to eq({
+                                      true => Vero::Senders::Base,
+                                      false => Vero::Senders::Base,
+                                      :none => Vero::Senders::Base
+                                    })
     end
 
     it 'should automatically find senders that are not defined' do

--- a/spec/lib/trackable_spec.rb
+++ b/spec/lib/trackable_spec.rb
@@ -84,13 +84,9 @@ describe Vero::Trackable do
           allow(@user).to receive(:with_vero_context).and_return(@context)
         end
 
-        context 'not using Ruby 1.8.7' do
-          before { stub_const('RUBY_VERSION', '1.9.3') }
-
-          it 'sends' do
-            expect(@user.track!(@request_params[:event_name], @request_params[:data])).to be_nil
-            expect(@user.track!(@request_params[:event_name])).to be_nil
-          end
+        it 'sends' do
+          expect(@user.track!(@request_params[:event_name], @request_params[:data])).to be_nil
+          expect(@user.track!(@request_params[:event_name])).to be_nil
         end
       end
     end
@@ -121,12 +117,8 @@ describe Vero::Trackable do
           allow(@user).to receive(:with_vero_context).and_return(@context)
         end
 
-        context 'and not using Ruby 1.8.7' do
-          before { stub_const('RUBY_VERSION', '1.9.3') }
-
-          it 'sends' do
-            expect(@user.identify!).to be_nil
-          end
+        it 'sends' do
+          expect(@user.identify!).to be_nil
         end
       end
     end
@@ -159,21 +151,8 @@ describe Vero::Trackable do
           allow(@user).to receive(:with_vero_context).and_return(@context)
         end
 
-        context 'and using Ruby 1.8.7' do
-          before { stub_const('RUBY_VERSION', '1.8.7') }
-
-          it 'raises an error' do
-            @context.config.disabled = false
-            expect { @user.with_vero_context.update_user! }.to raise_error(RuntimeError)
-          end
-        end
-
-        context 'and not using Ruby 1.8.7' do
-          before { stub_const('RUBY_VERSION', '1.9.3') }
-
-          it 'sends' do
-            expect(@user.with_vero_context.update_user!).to be_nil
-          end
+        it 'sends' do
+          expect(@user.with_vero_context.update_user!).to be_nil
         end
       end
     end
@@ -202,16 +181,14 @@ describe Vero::Trackable do
         expect(@user.with_vero_context.update_user_tags!).to eq(200)
       end
 
-      if RUBY_VERSION =~ /1\.9\./
-        it 'should send using another thread when async is set to true' do
-          context = Vero::Context.new(Vero::App.default_context)
-          context.subject = @user
-          context.config.async = true
+      it 'should send using another thread when async is set to true' do
+        context = Vero::Context.new(Vero::App.default_context)
+        context.subject = @user
+        context.config.async = true
 
-          allow(@user).to receive(:with_vero_context).and_return(context)
+        allow(@user).to receive(:with_vero_context).and_return(context)
 
-          expect(@user.with_vero_context.update_user_tags!).to be_nil
-        end
+        expect(@user.with_vero_context.update_user_tags!).to be_nil
       end
     end
 
@@ -243,12 +220,8 @@ describe Vero::Trackable do
           allow(@user).to receive(:with_vero_context).and_return(@context)
         end
 
-        context 'and using Ruby 1.9.3' do
-          before { stub_const('RUBY_VERSION', '1.9.3') }
-
-          it 'sends' do
-            expect(@user.with_vero_context.unsubscribe!).to be_nil
-          end
+        it 'sends' do
+          expect(@user.with_vero_context.unsubscribe!).to be_nil
         end
       end
     end


### PR DESCRIPTION
This PR takes care of some house keeping that we should have done around when merging #59. Notably it will prevent issues for customers still using `:thread` as their sender strategy.