### PR TITLE
improve: Added Github Action CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6.8
+          bundler-cache: true
+
+      - name: RuboCop
+        run: bundle exec rubocop
+
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: ["2.6.8", "2.7.8", "3.0.6", "3.1.4", "3.2.3", "3.3.0"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: RSpec
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - "2.0.0"
-  - "2.1.5"
-  - "2.2.0"
-script: bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,12 @@ gemspec
 group :development do
   gem 'rubocop'
 
-  gem 'delayed_job', '~> 3.0.0'
+  gem 'delayed_job'
   gem 'delayed_job_active_record'
-  gem 'rails', '~> 3.0'
+  gem 'rails'
   gem 'resque'
-  gem 'sidekiq', '~> 3.5.1'
-  gem 'sucker_punch', '~> 2.1.2'
+  gem 'sidekiq'
+  gem 'sucker_punch'
 end
 
 group :test do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'bundler/setup'
 require 'vero'
 require 'json'
 
-Dir[::File.expand_path('support/**/*.rb', __dir__)].sort.each { |f| require f }
+Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
We previously used TravisCI to run specs. This PR replaces this with a Github Action. It also removes the version locks on development dependencies as they are very old.