### PR TITLE
feat!: use tracking_api_key instead of the old api_key and secret

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- **BREAKING**: You are now required to use the tracking API key to authenticate. Visit https://connect.getvero.com/settings/project/tracking-api-keys to manage your tracking API keys. The original way of using API key and secret is no longer supported in this version.
+
 ## 0.9.0
 
 - *Added support for Sidekiq**. You can now use Sidekiq to deliver API requests to Vero. To do so, just specify `config.async = :sidekiq` in your config.rb file.

--- a/lib/vero/config.rb
+++ b/lib/vero/config.rb
@@ -5,10 +5,10 @@ require 'base64'
 module Vero
   class Config
     attr_writer :domain
-    attr_accessor :api_key, :secret, :development_mode, :async, :disabled, :logging
+    attr_accessor :tracking_api_key, :development_mode, :async, :disabled, :logging
 
     def self.available_attributes
-      %i[api_key secret development_mode async disabled logging domain]
+      %i[tracking_api_key development_mode async disabled logging domain]
     end
 
     def initialize
@@ -16,12 +16,12 @@ module Vero
     end
 
     def config_params
-      { api_key: api_key, secret: secret }
+      { tracking_api_key: tracking_api_key }
     end
 
     def request_params
       {
-        auth_token: auth_token,
+        tracking_api_key: tracking_api_key,
         development_mode: development_mode
       }.compact
     end
@@ -34,18 +34,8 @@ module Vero
       end
     end
 
-    def auth_token
-      return unless auth_token?
-
-      ::Base64.encode64("#{api_key}:#{secret}").gsub(/[\n ]/, '')
-    end
-
-    def auth_token?
-      !api_key.blank? && !secret.blank?
-    end
-
     def configured?
-      auth_token?
+      !tracking_api_key.blank?
     end
 
     def disable_requests!
@@ -57,8 +47,7 @@ module Vero
       self.development_mode = false
       self.async            = true
       self.logging          = false
-      self.api_key          = nil
-      self.secret           = nil
+      self.tracking_api_key = nil
     end
 
     def update_attributes(attributes = {})

--- a/lib/vero/version.rb
+++ b/lib/vero/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Vero
-  VERSION = '0.10.0'
+  VERSION = '1.0.0'
 end

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -8,11 +8,11 @@ describe Vero::Api::Events do
   describe :track! do
     it 'should call the TrackAPI object via the configured sender' do
       input = { event_name: 'test_event', identity: { email: 'james@getvero.com' }, data: { test: 'test' } }
-      expected = input.merge(auth_token: 'abc123', development_mode: true)
+      expected = input.merge(tracking_api_key: 'abc123', development_mode: true)
 
       mock_context = Vero::Context.new
       allow(mock_context.config).to receive(:configured?).and_return(true)
-      allow(mock_context.config).to receive(:auth_token).and_return('abc123')
+      allow(mock_context.config).to receive(:tracking_api_key).and_return('abc123')
       allow(mock_context.config).to receive(:development_mode).and_return(true)
 
       allow(Vero::App).to receive(:default_context).and_return(mock_context)
@@ -27,11 +27,11 @@ end
 describe Vero::Api::Users do
   let(:subject) { Vero::Api::Users }
   let(:mock_context) { Vero::Context.new }
-  let(:expected) { input.merge(auth_token: 'abc123', development_mode: true) }
+  let(:expected) { input.merge(tracking_api_key: 'abc123', development_mode: true) }
 
   before :each do
     allow(mock_context.config).to receive(:configured?).and_return(true)
-    allow(mock_context.config).to receive(:auth_token).and_return('abc123')
+    allow(mock_context.config).to receive(:tracking_api_key).and_return('abc123')
     allow(mock_context.config).to receive(:development_mode).and_return(true)
     allow(Vero::App).to receive(:default_context).and_return(mock_context)
   end

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -20,11 +20,11 @@ describe Vero::App do
     it 'should pass configuration defined in the block to the config file' do
       Vero::App.init
 
-      expect(context.config.api_key).to be_nil
+      expect(context.config.tracking_api_key).to be_nil
       Vero::App.init do |c|
-        c.api_key = 'abcd1234'
+        c.tracking_api_key = 'abcd1234'
       end
-      expect(context.config.api_key).to eq('abcd1234')
+      expect(context.config.tracking_api_key).to eq('abcd1234')
     end
 
     it 'should init should be able to set async' do

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -11,50 +11,36 @@ describe Vero::Config do
 
   describe :reset! do
     it 'should reset all attributes' do
-      config.api_key = 'abcd1234'
-      config.secret  = 'abcd1234'
+      config.tracking_api_key = 'abcd1234'
       config.reset!
 
-      expect(config.api_key).to be_nil
-      expect(config.secret).to be_nil
+      expect(config.tracking_api_key).to be_nil
     end
   end
 
-  describe :auth_token do
-    it 'should return nil if either api_key or secret are not set' do
-      config.api_key = nil
-      config.secret = 'abcd'
-      expect(config.auth_token).to be_nil
-
-      config.api_key = 'abcd'
-      config.secret = nil
-      expect(config.auth_token).to be_nil
-
-      config.api_key = 'abcd'
-      config.secret = 'abcd'
-      expect(config.auth_token).not_to be_nil
+  describe :tracking_api_key do
+    it 'should return nil if tracking_api_key is not set' do
+      config.tracking_api_key = nil
+      expect(config.tracking_api_key).to be_nil
     end
 
-    it 'should return an expected auth_token' do
-      config.api_key = 'abcd1234'
-      config.secret = 'efgh5678'
-      expect(config.auth_token).to eq('YWJjZDEyMzQ6ZWZnaDU2Nzg=')
+    it 'should return an expected tracking_api_key' do
+      config.tracking_api_key = 'abcd1234'
+      expect(config.tracking_api_key).to eq('abcd1234')
     end
   end
 
   describe :request_params do
-    it 'should return a hash of auth_token and development_mode if they are set' do
-      config.api_key = nil
-      config.secret = nil
+    it 'should return a hash of tracking_api_key and development_mode if they are set' do
+      config.tracking_api_key = nil
       config.development_mode = nil
       expect(config.request_params).to eq({})
 
-      config.api_key = 'abcd1234'
-      config.secret = 'abcd1234'
-      expect(config.request_params).to eq({ auth_token: 'YWJjZDEyMzQ6YWJjZDEyMzQ=' })
+      config.tracking_api_key = 'abcd1234'
+      expect(config.request_params).to eq({ tracking_api_key: 'abcd1234' })
 
       config.development_mode = true
-      expect(config.request_params).to eq({ auth_token: 'YWJjZDEyMzQ6YWJjZDEyMzQ=', development_mode: true })
+      expect(config.request_params).to eq({ tracking_api_key: 'abcd1234', development_mode: true })
     end
   end
 

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -5,22 +5,21 @@ require 'spec_helper'
 describe Vero::Context do
   let(:context) { Vero::Context.new }
 
-  it 'accepts multiple parameter types in contructor' do
-    context1 = Vero::Context.new({ api_key: 'blah', secret: 'didah' })
-    expect(context1).to be_a(Vero::Context)
-    expect(context1.config.api_key).to eq('blah')
-    expect(context1.config.secret).to eq('didah')
+  describe :initialize do
+    it 'accepts multiple parameter types' do
+      context1 = Vero::Context.new({ tracking_api_key: 'didah' })
+      expect(context1).to be_a(Vero::Context)
+      expect(context1.config.tracking_api_key).to eq('didah')
 
-    context2 = Vero::Context.new(context1)
-    expect(context2).to be_a(Vero::Context)
-    expect(context2).not_to be(context1)
-    expect(context2.config.api_key).to eq('blah')
-    expect(context2.config.secret).to eq('didah')
+      context2 = Vero::Context.new(context1)
+      expect(context2).to be_a(Vero::Context)
+      expect(context2).not_to be(context1)
+      expect(context2.config.tracking_api_key).to eq('didah')
 
-    context3 = Vero::Context.new VeroUser.new('api_key', 'secret')
-    expect(context3).to be_a(Vero::Context)
-    expect(context3.config.api_key).to eq('api_key')
-    expect(context3.config.secret).to eq('secret')
+      context3 = Vero::Context.new VeroUser.new('tracking_api_key')
+      expect(context3).to be_a(Vero::Context)
+      expect(context3.config.tracking_api_key).to eq('tracking_api_key')
+    end
   end
 
   describe :configure do
@@ -31,9 +30,9 @@ describe Vero::Context do
 
     it 'should pass configuration defined in the block to the config file' do
       context.configure do |c|
-        c.api_key = 'abcd1234'
+        c.tracking_api_key = 'abcd1234'
       end
-      expect(context.config.api_key).to eq('abcd1234')
+      expect(context.config.tracking_api_key).to eq('abcd1234')
     end
 
     it 'should init should be able to set async' do

--- a/spec/lib/trackable_spec.rb
+++ b/spec/lib/trackable_spec.rb
@@ -16,7 +16,7 @@ describe Vero::Trackable do
   before :each do
     @request_params = {
       event_name: 'test_event',
-      auth_token: 'YWJjZDEyMzQ6ZWZnaDU2Nzg=',
+      tracking_api_key: 'YWJjZDEyMzQ6ZWZnaDU2Nzg=',
       identity: { email: 'durkster@gmail.com', age: 20, _user_type: 'User' },
       data: { test: 1 },
       development_mode: true
@@ -40,8 +40,7 @@ describe Vero::Trackable do
   context 'the gem has been configured' do
     before do
       Vero::App.init do |c|
-        c.api_key = 'abcd1234'
-        c.secret = 'efgh5678'
+        c.tracking_api_key = 'YWJjZDEyMzQ6ZWZnaDU2Nzg='
         c.async = false
       end
     end
@@ -300,8 +299,8 @@ describe Vero::Trackable do
     describe :with_vero_context do
       it 'should be able to change contexts' do
         user = User.new
-        expect(user.with_default_vero_context.config.config_params).to eq({ api_key: 'abcd1234', secret: 'efgh5678' })
-        expect(user.with_vero_context({ api_key: 'boom', secret: 'tish' }).config.config_params).to eq({ api_key: 'boom', secret: 'tish' })
+        expect(user.with_default_vero_context.config.config_params).to eq({ tracking_api_key: 'YWJjZDEyMzQ6ZWZnaDU2Nzg=' })
+        expect(user.with_vero_context({ tracking_api_key: 'boom' }).config.config_params).to eq({ tracking_api_key: 'boom' })
       end
     end
 
@@ -310,7 +309,7 @@ describe Vero::Trackable do
 
       request_params = {
         event_name: 'test_event',
-        auth_token: 'YWJjZDEyMzQ6ZWZnaDU2Nzg=',
+        tracking_api_key: 'YWJjZDEyMzQ6ZWZnaDU2Nzg=',
         identity: { email: 'durkster@gmail.com', age: 20, _user_type: 'UserWithoutInterface' },
         data: { test: 1 },
         development_mode: true

--- a/spec/lib/view_helpers_spec.rb
+++ b/spec/lib/view_helpers_spec.rb
@@ -29,19 +29,17 @@ describe Vero::ViewHelpers::Javascript do
 
     context 'Vero::App has been properly configured' do
       before :each do
-        @api_key = 'abcd1234'
-        @api_secret = 'secret'
+        @tracking_api_key = 'abcd1234'
         @api_dev_mode = false
 
         Vero::App.init do |c|
-          c.api_key           = @api_key
-          c.secret            = @api_secret
-          c.development_mode  = @api_dev_mode
+          c.tracking_api_key = @tracking_api_key
+          c.development_mode = @api_dev_mode
         end
       end
 
       it 'should return a properly formatted javascript snippet' do
-        result = "<script type=\"text/javascript\">var _veroq = _veroq || [];setTimeout(function(){if(typeof window.Semblance==\"undefined\"){console.log(\"Vero did not load in time.\");for(var i=0;i<_veroq.length;i++){a=_veroq[i];if(a.length==3&&typeof a[2]==\"function\")a[2](null,false);}}},3000);_veroq.push(['init', {\"api_key\": \"#{@api_key}\", \"secret\": \"#{@api_secret}\"}]);(function() {var ve = document.createElement('script'); ve.type = 'text/javascript'; ve.async = true; ve.src = '//getvero.com/assets/m.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ve, s);})();</script>"
+        result = "<script type=\"text/javascript\">var _veroq = _veroq || [];setTimeout(function(){if(typeof window.Semblance==\"undefined\"){console.log(\"Vero did not load in time.\");for(var i=0;i<_veroq.length;i++){a=_veroq[i];if(a.length==3&&typeof a[2]==\"function\")a[2](null,false);}}},3000);_veroq.push(['init', {\"tracking_api_key\": \"#{@tracking_api_key}\"}]);(function() {var ve = document.createElement('script'); ve.type = 'text/javascript'; ve.async = true; ve.src = '//getvero.com/assets/m.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ve, s);})();</script>"
         expect(subject.vero_javascript_tag).to eq(result)
       end
     end

--- a/spec/support/vero_user_support.rb
+++ b/spec/support/vero_user_support.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-VeroUser = Struct.new(:api_key, :secret)
+VeroUser = Struct.new(:tracking_api_key)


### PR DESCRIPTION
The new tracking API keys replace the existing API keys, secrets and auth tokens.

This PR updates the SDK to accept the tracking API keys, and removes the support for API keys and secrets.

BREAKING CHANGE: remove the support of `api_key` and `secret` as a way of authentication.