### PR TITLE
chore: Removed Object#blank? monkey patch

### DIFF
--- a/lib/vero.rb
+++ b/lib/vero.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rest-client"
-require "vero/utility/ext"
 
 module Vero
   autoload :Config, "vero/config"

--- a/lib/vero/api/events/track_api.rb
+++ b/lib/vero/api/events/track_api.rb
@@ -14,7 +14,7 @@ module Vero
           end
 
           def validate!
-            raise ArgumentError, "Missing :event_name" if options[:event_name].to_s.blank?
+            raise ArgumentError, "Missing :event_name" if options[:event_name].to_s.strip.empty?
             raise ArgumentError, ":data must be either nil or a Hash" unless options[:data].nil? || options[:data].is_a?(Hash)
           end
         end

--- a/lib/vero/api/users/delete_api.rb
+++ b/lib/vero/api/users/delete_api.rb
@@ -14,7 +14,7 @@ module Vero
           end
 
           def validate!
-            raise ArgumentError, "Missing :id" if options[:id].to_s.blank?
+            raise ArgumentError, "Missing :id" if options[:id].to_s.strip.empty?
           end
         end
       end

--- a/lib/vero/api/users/edit_api.rb
+++ b/lib/vero/api/users/edit_api.rb
@@ -14,7 +14,10 @@ module Vero
           end
 
           def validate!
-            raise ArgumentError, "Missing :id or :email" if options[:id].to_s.blank? && options[:email].to_s.blank?
+            if options[:id].to_s.strip.empty? && options[:email].to_s.strip.empty?
+              raise ArgumentError, "Missing :id or :email"
+            end
+
             raise ArgumentError, ":changes must be a Hash" unless options[:changes].is_a?(Hash)
           end
         end

--- a/lib/vero/api/users/edit_tags_api.rb
+++ b/lib/vero/api/users/edit_tags_api.rb
@@ -18,7 +18,7 @@ module Vero
               raise ArgumentError, "Missing :id or :email"
             end
 
-            raise ArgumentError, ":add must an Array if present" unless options[:add].nil? || options[:add].is_a?(Array)
+            raise ArgumentError, ':add must be an Array if present' unless options[:add].nil? || options[:add].is_a?(Array)
 
             unless options[:remove].nil? || options[:remove].is_a?(Array)
               raise ArgumentError, ":remove must an Array if present"

--- a/lib/vero/api/users/edit_tags_api.rb
+++ b/lib/vero/api/users/edit_tags_api.rb
@@ -14,10 +14,19 @@ module Vero
           end
 
           def validate!
-            raise ArgumentError, "Missing :id or :email" if options[:id].to_s.blank? && options[:email].to_s.blank?
+            if options[:id].to_s.strip.empty? && options[:email].to_s.strip.empty?
+              raise ArgumentError, "Missing :id or :email"
+            end
+
             raise ArgumentError, ":add must an Array if present" unless options[:add].nil? || options[:add].is_a?(Array)
-            raise ArgumentError, ":remove must an Array if present" unless options[:remove].nil? || options[:remove].is_a?(Array)
-            raise ArgumentError, "Either :add or :remove must be present" if options[:remove].nil? && options[:add].nil?
+
+            unless options[:remove].nil? || options[:remove].is_a?(Array)
+              raise ArgumentError, ":remove must an Array if present"
+            end
+
+            return unless options[:remove].nil? && options[:add].nil?
+
+            raise ArgumentError, "Either :add or :remove must be present"
           end
         end
       end

--- a/lib/vero/api/users/edit_tags_api.rb
+++ b/lib/vero/api/users/edit_tags_api.rb
@@ -18,10 +18,10 @@ module Vero
               raise ArgumentError, "Missing :id or :email"
             end
 
-            raise ArgumentError, ':add must be an Array if present' unless options[:add].nil? || options[:add].is_a?(Array)
+            raise ArgumentError, ":add must be an Array if present" unless options[:add].nil? || options[:add].is_a?(Array)
 
             unless options[:remove].nil? || options[:remove].is_a?(Array)
-              raise ArgumentError, ":remove must an Array if present"
+              raise ArgumentError, ":remove must be an Array if present"
             end
 
             return unless options[:remove].nil? && options[:add].nil?

--- a/lib/vero/api/users/reidentify_api.rb
+++ b/lib/vero/api/users/reidentify_api.rb
@@ -14,8 +14,8 @@ module Vero
           end
 
           def validate!
-            raise ArgumentError, "Missing :id" if options[:id].to_s.blank?
-            raise ArgumentError, "Missing :new_id" if options[:new_id].to_s.blank?
+            raise ArgumentError, "Missing :id" if options[:id].to_s.strip.empty?
+            raise ArgumentError, "Missing :new_id" if options[:new_id].to_s.strip.empty?
           end
         end
       end

--- a/lib/vero/api/users/resubscribe_api.rb
+++ b/lib/vero/api/users/resubscribe_api.rb
@@ -14,7 +14,9 @@ module Vero
           end
 
           def validate!
-            raise ArgumentError, "Missing :id or :email" if options[:id].to_s.blank? && options[:email].to_s.blank?
+            return unless options[:id].to_s.strip.empty? && options[:email].to_s.strip.empty?
+
+            raise ArgumentError, "Missing :id or :email"
           end
         end
       end

--- a/lib/vero/api/users/track_api.rb
+++ b/lib/vero/api/users/track_api.rb
@@ -14,8 +14,13 @@ module Vero
           end
 
           def validate!
-            raise ArgumentError, "Missing :id or :email" if options[:id].to_s.blank? && options[:email].to_s.blank?
-            raise ArgumentError, ":data must be either nil or a Hash" unless options[:data].nil? || options[:data].is_a?(Hash)
+            if options[:id].to_s.strip.empty? && options[:email].to_s.strip.empty?
+              raise ArgumentError, "Missing :id or :email"
+            end
+
+            return if options[:data].nil? || options[:data].is_a?(Hash)
+
+            raise ArgumentError, ":data must be either nil or a Hash"
           end
         end
       end

--- a/lib/vero/api/users/unsubscribe_api.rb
+++ b/lib/vero/api/users/unsubscribe_api.rb
@@ -14,7 +14,9 @@ module Vero
           end
 
           def validate!
-            raise ArgumentError, "Missing :id or :email" if options[:id].to_s.blank? && options[:email].to_s.blank?
+            return unless options[:id].to_s.strip.empty? && options[:email].to_s.strip.empty?
+
+            raise ArgumentError, "Missing :id or :email"
           end
         end
       end

--- a/lib/vero/config.rb
+++ b/lib/vero/config.rb
@@ -27,7 +27,7 @@ module Vero
     end
 
     def domain
-      if @domain.nil? || @domain.empty?
+      if @domain.nil? || @domain.to_s.empty?
         "https://api.getvero.com"
       else
         a_domain = @domain.to_s

--- a/lib/vero/config.rb
+++ b/lib/vero/config.rb
@@ -27,10 +27,11 @@ module Vero
     end
 
     def domain
-      if @domain.blank?
+      if @domain.nil? || @domain.empty?
         "https://api.getvero.com"
       else
-        %r{https?://.+}.match?(@domain) ? @domain : "http://#{@domain}"
+        a_domain = @domain.to_s
+        %r{https?://.+}.match?(a_domain) ? a_domain : "http://#{a_domain}"
       end
     end
 

--- a/lib/vero/utility/ext.rb
+++ b/lib/vero/utility/ext.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class Object
-  def blank?
-    respond_to?(:empty?) ? empty? : !self
-  end
-end


### PR DESCRIPTION
Vero gem was unnecessarily monkey patching `blank?` into `Object`. This PR removes the monkey patch and replaces `blank?` with `nil?` and `empty?`.