### PR TITLE
chore: Removed development_mode config field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,15 @@
 
 - **BREAKING**: You are now required to use the tracking API key to authenticate. Visit https://connect.getvero.com/settings/project/tracking-api-keys to manage your tracking API keys. The original way of using API key and secret is no longer supported in this version.
 
+- **BREAKING**: Removed "development_mode" flag (previously deprecated in 0.8.0)
+
+- **BREAKING**: Raised minimum Ruby version requirement to 2.7
+
+- Added Zeitwerk for improved code autoloading
+
 ## 0.9.0
 
-- *Added support for Sidekiq**. You can now use Sidekiq to deliver API requests to Vero. To do so, just specify `config.async = :sidekiq` in your config.rb file.
+- **Added support for Sidekiq**. You can now use Sidekiq to deliver API requests to Vero. To do so, just specify `config.async = :sidekiq` in your config.rb file.
 
 ## 0.8.0
 

--- a/lib/vero/config.rb
+++ b/lib/vero/config.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class Vero::Config
-  attr_writer :domain
-  attr_accessor :tracking_api_key, :development_mode, :async, :disabled, :logging
+  attr_writer :development_mode # Deprecated field
 
-  ACCEPTED_ATTRIBUTES = %i[tracking_api_key development_mode async disabled logging domain]
+  attr_writer :domain
+  attr_accessor :tracking_api_key, :async, :disabled, :logging
+
+  ACCEPTED_ATTRIBUTES = %i[tracking_api_key async disabled logging domain]
 
   # Extracts accepted attributes from the given object. It isn't necessarily a Vero::Config instance.
   def self.extract_accepted_attrs_from(object)
@@ -22,10 +24,7 @@ class Vero::Config
   end
 
   def request_params
-    {
-      tracking_api_key: tracking_api_key,
-      development_mode: development_mode
-    }.compact
+    {tracking_api_key: tracking_api_key}.compact
   end
 
   def domain
@@ -47,7 +46,6 @@ class Vero::Config
 
   def reset!
     self.disabled = false
-    self.development_mode = false
     self.async = true
     self.logging = false
     self.tracking_api_key = nil

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -8,12 +8,11 @@ describe Vero::Api::Events do
   describe :track! do
     it "should call the TrackAPI object via the configured sender" do
       input = {event_name: "test_event", identity: {email: "james@getvero.com"}, data: {test: "test"}}
-      expected = input.merge(tracking_api_key: "abc123", development_mode: true)
+      expected = input.merge(tracking_api_key: "abc123")
 
       mock_context = Vero::Context.new
       allow(mock_context.config).to receive(:configured?).and_return(true)
       allow(mock_context.config).to receive(:tracking_api_key).and_return("abc123")
-      allow(mock_context.config).to receive(:development_mode).and_return(true)
 
       allow(Vero::App).to receive(:default_context).and_return(mock_context)
 
@@ -27,12 +26,11 @@ end
 describe Vero::Api::Users do
   let(:subject) { Vero::Api::Users }
   let(:mock_context) { Vero::Context.new }
-  let(:expected) { input.merge(tracking_api_key: "abc123", development_mode: true) }
+  let(:expected) { input.merge(tracking_api_key: "abc123") }
 
   before :each do
     allow(mock_context.config).to receive(:configured?).and_return(true)
     allow(mock_context.config).to receive(:tracking_api_key).and_return("abc123")
-    allow(mock_context.config).to receive(:development_mode).and_return(true)
     allow(Vero::App).to receive(:default_context).and_return(mock_context)
   end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -33,14 +33,10 @@ describe Vero::Config do
   describe :request_params do
     it "should return a hash of tracking_api_key and development_mode if they are set" do
       config.tracking_api_key = nil
-      config.development_mode = nil
       expect(config.request_params).to eq({})
 
       config.tracking_api_key = "abcd1234"
       expect(config.request_params).to eq({tracking_api_key: "abcd1234"})
-
-      config.development_mode = true
-      expect(config.request_params).to eq({tracking_api_key: "abcd1234", development_mode: true})
     end
   end
 
@@ -57,33 +53,6 @@ describe Vero::Config do
 
       config.domain = "http://test.unbelieveable.com.au"
       expect(config.domain).to eq("http://test.unbelieveable.com.au")
-    end
-  end
-
-  describe :development_mode do
-    it "by default it should return false regardless of Rails environment" do
-      stub_env("development") do
-        config = Vero::Config.new
-        expect(config.development_mode).to be(false)
-      end
-
-      stub_env("test") do
-        config = Vero::Config.new
-        expect(config.development_mode).to be(false)
-      end
-
-      stub_env("production") do
-        config = Vero::Config.new
-        expect(config.development_mode).to be(false)
-      end
-    end
-
-    it "can be overritten with the config block" do
-      config.development_mode = true
-      expect(config.request_params[:development_mode]).to be(true)
-
-      config.reset!
-      expect(config.request_params[:development_mode]).to be(false)
     end
   end
 

--- a/spec/lib/trackable_spec.rb
+++ b/spec/lib/trackable_spec.rb
@@ -18,8 +18,7 @@ describe Vero::Trackable do
       event_name: "test_event",
       tracking_api_key: "YWJjZDEyMzQ6ZWZnaDU2Nzg=",
       identity: {email: "user@getvero.com", age: 20, _user_type: "User"},
-      data: {test: 1},
-      development_mode: true
+      data: {test: 1}
     }
     @url = "https://api.getvero.com/api/v1/track.json"
     @user = User.new
@@ -311,8 +310,7 @@ describe Vero::Trackable do
         event_name: "test_event",
         tracking_api_key: "YWJjZDEyMzQ6ZWZnaDU2Nzg=",
         identity: {email: "user@getvero.com", age: 20, _user_type: "UserWithoutInterface"},
-        data: {test: 1},
-        development_mode: true
+        data: {test: 1}
       }
 
       context = Vero::Context.new(Vero::App.default_context)

--- a/spec/lib/view_helpers_spec.rb
+++ b/spec/lib/view_helpers_spec.rb
@@ -30,11 +30,9 @@ describe Vero::ViewHelpers::Javascript do
     context "Vero::App has been properly configured" do
       before :each do
         @tracking_api_key = "abcd1234"
-        @api_dev_mode = false
 
         Vero::App.init do |c|
           c.tracking_api_key = @tracking_api_key
-          c.development_mode = @api_dev_mode
         end
       end
 


### PR DESCRIPTION
`development_mode` has been deprecated for several years. This PR renders the config option useless.

Note: `Vero::Config` will still accept `development_mode` but it will never be used.