### PR TITLE
bug: Fixed tracking api key leaking in logs

### DIFF
--- a/lib/vero/http_client.rb
+++ b/lib/vero/http_client.rb
@@ -45,7 +45,7 @@ class Vero::HttpClient
     log_params = params.dup
 
     if log_params.key?(:payload)
-      log_params[:payload] = body.merge(tracking_api_key: "[FILTERED]").to_json
+      log_params[:payload] = Vero::App.sanitize_log_payload(body).to_json
     end
 
     @logger.info("Request: #{log_params.inspect}")

--- a/lib/vero/sender.rb
+++ b/lib/vero/sender.rb
@@ -10,7 +10,7 @@ module Vero
       sender = senders[sender_strategy].new
       sender.call(api_class, domain, options)
     rescue => e
-      Vero::App.log(new, "method: #{api_class.name}, options: #{JSON.dump(options)}, error: #{e.message}")
+      Vero::App.log_api_call(api_class.name, options, e.message)
       raise e
     end
 

--- a/lib/vero/senders/base.rb
+++ b/lib/vero/senders/base.rb
@@ -5,7 +5,7 @@ class Vero::Senders::Base
     api_class = get_api_class(api_class)
 
     resp = enqueue_work(api_class, domain, options)
-    Vero::App.log(self, "method: #{api_class.name}, options: #{JSON.dump(options)}, response: #{log_message}")
+    Vero::App.log_api_call(api_class.name, options, log_message)
 
     resp
   end

--- a/lib/vero/utility/logger.rb
+++ b/lib/vero/utility/logger.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Vero::Utility::Logger
+  FILTER_STRING = "[FILTERED]"
+
   def self.included(base)
     base.extend(ClassMethods)
   end
@@ -9,12 +11,33 @@ module Vero::Utility::Logger
     def log(object, message)
       return unless Vero::App.default_context.config.logging && !defined?(RSpec)
 
-      message = "#{object.class.name}: #{message}"
+      prefix = case object
+      when String
+        object
+      else
+        object.class.name
+      end
+
+      message = "#{prefix}: #{message}"
 
       if (logger = self.logger)
         logger.info(message)
       else
         puts(message)
+      end
+    end
+
+    def log_api_call(api_class, options, msg)
+      log(api_class, "params: #{sanitize_log_payload(options).to_json}, response: #{msg}")
+    end
+
+    def sanitize_log_payload(payload)
+      if payload.key?(:tracking_api_key)
+        payload.merge(tracking_api_key: FILTER_STRING)
+      elsif payload.key?("tracking_api_key")
+        payload.merge("tracking_api_key" => FILTER_STRING)
+      else
+        payload
       end
     end
 

--- a/lib/vero/workers/resque_worker.rb
+++ b/lib/vero/workers/resque_worker.rb
@@ -8,6 +8,6 @@ class Vero::ResqueWorker
   def self.perform(api_class, domain, options)
     Vero::Senders::Base.new.call(api_class, domain, options)
   rescue => e
-    Vero::App.log(self, "method: #{api_class}, options: #{options.to_json}, response: #{e.message}")
+    Vero::App.log_api_call(api_class, options, e.message)
   end
 end

--- a/lib/vero/workers/sidekiq_worker.rb
+++ b/lib/vero/workers/sidekiq_worker.rb
@@ -8,6 +8,6 @@ class Vero::SidekiqWorker
   def perform(api_class, domain, options)
     Vero::Senders::Base.new.call(api_class, domain, options)
   rescue => e
-    Vero::App.log(self, "method: #{api_class}, options: #{options.to_json}, response: #{e.message}")
+    Vero::App.log_api_call(api_class, options, e.message)
   end
 end

--- a/lib/vero/workers/sucker_punch_worker.rb
+++ b/lib/vero/workers/sucker_punch_worker.rb
@@ -8,6 +8,6 @@ class Vero::SuckerPunchWorker
   def perform(api_class, domain, options)
     Vero::Senders::Base.new.call(api_class, domain, options)
   rescue => e
-    Vero::App.log(self, "method: #{api_class}, options: #{options.to_json}, response: #{e.message}")
+    Vero::App.log_api_call(api_class, options, e.message)
   end
 end


### PR DESCRIPTION
Whilst working on #91, we discovered that the `tracking_api_key` was being leaked in logs (when `config.logger = true` and using Rails). This PR properly filters the value from API req logs.